### PR TITLE
feat: board/[id] 페이지 댓글 수정 기능 추가

### DIFF
--- a/src/app/boards/[id]/page.tsx
+++ b/src/app/boards/[id]/page.tsx
@@ -10,8 +10,6 @@ export default async function Board({ params }: { params: Promise<{ id: string }
         <BoardContent>
           <BoardDetail id={id}></BoardDetail>
         </BoardContent>
-      </div>
-      <div className='flex flex-col items-center justify-center '>
         <BoardComments id={id}></BoardComments>
       </div>
     </>

--- a/src/components/page/boardDetail/BoardComment.tsx
+++ b/src/components/page/boardDetail/BoardComment.tsx
@@ -3,11 +3,13 @@
 import { motion } from 'framer-motion';
 import { dateFormater } from '@/utils/date';
 import { CommentResponse } from '@/components/page/boardDetail/BoardComments';
+import { useState } from 'react';
 
 import Image from 'next/image';
 import BasicProfileImage from '@/assets/images/icon.svg';
-import EditIcon from '@/assets/images/type=edit.svg';
-import DeleteIcon from '@/assets/images/type=delete.svg';
+import { FiEdit2 } from 'react-icons/fi';
+import { FaRegTrashAlt } from 'react-icons/fa';
+import CommentEdit from './CommentEdit';
 
 interface CommentItemProps {
   id: number | undefined;
@@ -15,7 +17,8 @@ interface CommentItemProps {
 }
 
 const BoardComment = ({ id, comment }: CommentItemProps) => {
-  const isEditing = false;
+  const [isEditing, setIsEditing] = useState(false);
+
   const {
     content,
     createdAt,
@@ -25,9 +28,9 @@ const BoardComment = ({ id, comment }: CommentItemProps) => {
     <>
       <>
         <div className={`mt-7 ${isEditing ? 'hidden' : ''}`}>
-          <div className=' relative min-w-[320px] gap-2.5 rounded-10 px-5 py-4 shadow-md'>
+          <div className=' relative min-w-[320px] gap-2.5 rounded-lg px-5 py-4 shadow-md'>
             <div className='flex '>
-              <div className='relative size-10 shrink-0 rounded-full md:size-[50px]'>
+              <div className='relative size-10 shrink-0 rounded-full overflow-hidden md:size-[50px]'>
                 {image ? (
                   <Image src={image} alt='프로필 이미지' fill style={{ objectFit: 'cover' }} />
                 ) : (
@@ -46,12 +49,13 @@ const BoardComment = ({ id, comment }: CommentItemProps) => {
             </div>
             <div className=' absolute right-5 top-4 flex justify-end gap-2'>
               {id === id && (
+                // edit, delete 컴포넌트 분리 고려해보기
                 <>
-                  <motion.div className='hoverMotion'>
-                    <EditIcon />
+                  <motion.div className='hoverMotion' onClick={() => setIsEditing(true)}>
+                    <FiEdit2 className='text-grayscale-400' />
                   </motion.div>
                   <motion.div className='hoverMotion'>
-                    <DeleteIcon />
+                    <FaRegTrashAlt className='text-grayscale-400' />
                   </motion.div>
                 </>
               )}
@@ -59,9 +63,26 @@ const BoardComment = ({ id, comment }: CommentItemProps) => {
           </div>
         </div>
 
-        {/* {isEditing && (
-          <CommentEditModal comment={comment} onCommentUpdated={handleCommentUpdated} />
-        )} */}
+        {isEditing && (
+          <div className='bg-grayscale-50 rounded-lg mt-7 p-5 shadow-md'>
+            <div className='flex'>
+              <div className='relative size-10 shrink-0 rounded-full overflow-hidden md:size-[50px]'>
+                {image ? (
+                  <Image src={image} alt='프로필 이미지' fill style={{ objectFit: 'cover' }} />
+                ) : (
+                  <BasicProfileImage />
+                )}
+              </div>
+              <div className='  ml-[15px] flex-col break-words text-grayscale-500 lg:max-w-none'>
+                <div className='text-lg-semibold lg:text-2lg-semibold '>{name}</div>
+                <div className='text-md-regular text-grayscale-400 lg:text-lg-regular'>
+                  {dateFormater(createdAt)}
+                </div>
+              </div>
+            </div>
+            <CommentEdit comment={comment} isEdit={setIsEditing} />
+          </div>
+        )}
       </>
     </>
   );

--- a/src/components/page/boardDetail/BoardContent.tsx
+++ b/src/components/page/boardDetail/BoardContent.tsx
@@ -11,7 +11,7 @@ const BoardContent = ({ children }: { children: React.ReactNode }) => {
       >
         {children}
       </div>
-      <Button variant={'secondary'} size={'sm'} className={'w-[140px] h-[45px]'}>
+      <Button variant={'secondary'} size={'sm'} className={'w-[140px] h-[45px] justify-center'}>
         <Link href={'/boards'}>목록으로</Link>
       </Button>
     </>

--- a/src/components/page/boardDetail/CommentEdit.tsx
+++ b/src/components/page/boardDetail/CommentEdit.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { CommentResponse } from '@/components/page/boardDetail/BoardComments';
+import Button from '@/components/common/Button';
+
+interface CommentEditProps {
+  comment: CommentResponse;
+  isEdit: React.Dispatch<React.SetStateAction<boolean>>;
+  // onCommentUpdated: (updatedComment: CommentResponse) => void;
+}
+
+const CommentEdit = ({ comment, isEdit }: CommentEditProps) => {
+  const [characterCount, setCharacterCount] = useState(0);
+  const [editedContent, setEditedContent] = useState(comment.content);
+  const MAX_CHARACTERS = 500;
+
+  useEffect(() => {
+    setCharacterCount(comment.content.length);
+  }, [comment.content]);
+
+  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setEditedContent(e.target.value);
+    setCharacterCount(e.target.value.length);
+  };
+
+  const handleSaveComment = async () => {
+    try {
+      // const updatedComment = await API(comment.id, { content: editedContent });
+      // onCommentUpdated(updatedComment);
+    } catch (error) {
+      console.log(error);
+      // ({ type: 'error', message: '댓글을 작성해주세요.' });
+    }
+  };
+
+  return (
+    <>
+      <div className='mt-4 min-w-[320px] rounded-lg bg-grayscale-100 p-4 shadow-md'>
+        <h3 className='text-md-semibold text-grayscale-500 lg:text-lg-semibold'>댓글 수정</h3>
+        <textarea
+          value={editedContent}
+          onChange={handleContentChange}
+          className='resize-none border-none outline-none h-[55%] w-full overflow-hidden bg-grayscale-100 pt-2 text-grayscale-500'
+          placeholder='댓글을 수정하세요.'
+          maxLength={MAX_CHARACTERS}
+        />
+
+        <div className='flex items-end justify-between'>
+          <div className='text-grayscale-300'>
+            {characterCount}/{MAX_CHARACTERS}
+          </div>
+          <div className='flex gap-2'>
+            <Button variant='secondary' onClick={() => isEdit(false)}>
+              취소
+            </Button>
+            <Button variant='primary' onClick={handleSaveComment}>
+              수정
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default CommentEdit;

--- a/src/components/page/boardDetail/CommentEdit.tsx
+++ b/src/components/page/boardDetail/CommentEdit.tsx
@@ -36,7 +36,7 @@ const CommentEdit = ({ comment, isEdit }: CommentEditProps) => {
 
   return (
     <>
-      <div className='mt-4 min-w-[320px] rounded-lg bg-grayscale-100 p-4 shadow-md'>
+      <div className='mt-4 min-w-[300px] rounded-lg bg-grayscale-100 p-4 shadow-md'>
         <h3 className='text-md-semibold text-grayscale-500 lg:text-lg-semibold'>댓글 수정</h3>
         <textarea
           value={editedContent}


### PR DESCRIPTION
# ✨ 댓글 수정 기능

![화면 기록 2025-07-19 오후 5 38 24](https://github.com/user-attachments/assets/7fcd2418-5277-4f04-9d74-288cc90bc95a)

피그마 문서에 참고 할 만한 디자인 시안이 없어서 
판다마켓의 디자인을 짬뽕해서 만들었습니다..

취소 버튼은 단순하게 isEdit을 props 로 받아와서 false로 만들어주는 동작으로 구현했습니다
실제 edit 동작은 로그인이 구현된 이후 수정할 예정입니다