### PR TITLE
feat: textEditor 하단클릭시 Editor에 focus되도록 기능 추가

### DIFF
--- a/src/components/common/TextEditor/ContentEditor.tsx
+++ b/src/components/common/TextEditor/ContentEditor.tsx
@@ -1,5 +1,6 @@
 import { EditorContent, type Editor } from '@tiptap/react';
 import ImageAlignToolBar from './textarea/ImageAlignToolBar';
+import EditorClickCatcher from './textarea/EditorClickCatcher';
 
 interface Props {
   editor: Editor;
@@ -7,9 +8,10 @@ interface Props {
 
 const ContentEditor = ({ editor }: Props) => {
   return (
-    <div>
+    <div className='flex flex-col h-full'>
       <ImageAlignToolBar editor={editor} />
       <EditorContent editor={editor} />
+      <EditorClickCatcher editor={editor} />
     </div>
   );
 };

--- a/src/components/common/TextEditor/ContentEditor.tsx
+++ b/src/components/common/TextEditor/ContentEditor.tsx
@@ -1,4 +1,5 @@
 import { EditorContent, type Editor } from '@tiptap/react';
+import ImageAlignToolBar from './textarea/ImageAlignToolBar';
 
 interface Props {
   editor: Editor;
@@ -7,6 +8,7 @@ interface Props {
 const ContentEditor = ({ editor }: Props) => {
   return (
     <div>
+      <ImageAlignToolBar editor={editor} />
       <EditorContent editor={editor} />
     </div>
   );

--- a/src/components/common/TextEditor/textarea/EditorClickCatcher.tsx
+++ b/src/components/common/TextEditor/textarea/EditorClickCatcher.tsx
@@ -1,0 +1,15 @@
+import type { Editor } from '@tiptap/react';
+
+interface Props {
+  editor: Editor;
+}
+
+const EditorClickCatcher = ({ editor }: Props) => {
+  const handleClick = () => {
+    if (!editor) return;
+    editor.commands.focus('end');
+  };
+  return <div className='w-full grow cursor-text' onClick={handleClick} />;
+};
+
+export default EditorClickCatcher;

--- a/src/components/common/TextEditor/textarea/ImageAlignToolBar.tsx
+++ b/src/components/common/TextEditor/textarea/ImageAlignToolBar.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useRef, useState } from 'react';
+import type { Editor } from '@tiptap/react';
+import { createPortal } from 'react-dom';
+import { NodeSelection } from 'prosemirror-state';
+import EditorButton from '../toolbar/components/EditorButton';
+import clsx from 'clsx';
+import { buttonActiveStyle, buttonDefaultStyle, toolbarStyle } from '../toolbar/toolBarStyle';
+import { twMerge } from 'tailwind-merge';
+
+interface Props {
+  editor: Editor;
+}
+
+type ImageAlignType = 'left' | 'center' | 'right' | 'justify' | undefined;
+
+const ImageAlignToolBar = ({ editor }: Props) => {
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  const imageWrapperRef = useRef<HTMLElement>(null);
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
+  const [imageAlignType, setImageAlignType] = useState<ImageAlignType | null>(null);
+  useEffect(() => {
+    if (!editor) return;
+
+    const updateAlign = () => {
+      if (editor.isActive('localImage', { align: 'left' })) return setImageAlignType('left');
+      if (editor.isActive('localImage', { align: 'center' })) return setImageAlignType('center');
+      if (editor.isActive('localImage', { align: 'right' })) return setImageAlignType('right');
+      setImageAlignType(null); // 선택 해제되면 초기화
+    };
+
+    const updatePosition = () => {
+      const { state, view } = editor;
+      const { selection } = state;
+
+      // 이미지 노드인지 확인
+      if (selection instanceof NodeSelection && selection.node.type.name === 'localImage') {
+        const dom = view.nodeDOM(selection.from) as HTMLElement;
+        const imageWrapper = dom.closest('[data-image-outer]') as HTMLElement;
+        imageWrapperRef.current = imageWrapper;
+        if (dom) {
+          const rect = dom.getBoundingClientRect();
+
+          setCoords({
+            top: rect.top + window.scrollY - 10, // 혹은 원래대로 -36, 상황 맞게
+            left: rect.left + window.scrollX + rect.width / 2,
+          });
+        }
+      } else {
+        setCoords(null);
+      }
+    };
+    updateAlign(); // 초기 렌더 시 실행
+    updatePosition();
+    editor.on('selectionUpdate', updatePosition);
+    editor.on('transaction', updateAlign);
+
+    return () => {
+      editor.off('selectionUpdate', updatePosition);
+      editor.off('transaction', updateAlign);
+    };
+  }, [editor]);
+
+  if (!coords) return null;
+
+  return createPortal(
+    <div
+      ref={toolbarRef}
+      className={twMerge(clsx(toolbarStyle, 'absolute z-10 px-3 py-1 pointer-events-auto'))}
+      style={{
+        top: coords.top,
+        left: coords.left,
+        transform: 'translateX(-50%)',
+      }}
+    >
+      <EditorButton
+        variant='left'
+        onClick={() => editor?.chain().focus().setImageAlign('left').run()}
+        className={clsx(buttonDefaultStyle, imageAlignType === 'left' && buttonActiveStyle)}
+      />
+      <EditorButton
+        variant='center'
+        onClick={() => editor?.chain().focus().setImageAlign('center').run()}
+        className={clsx(buttonDefaultStyle, imageAlignType === 'center' && buttonActiveStyle)}
+      />
+      <EditorButton
+        variant='right'
+        onClick={() => editor?.chain().focus().setImageAlign('right').run()}
+        className={clsx(buttonDefaultStyle, imageAlignType === 'right' && buttonActiveStyle)}
+      />
+    </div>,
+    document.body,
+  );
+};
+
+export default ImageAlignToolBar;

--- a/src/components/common/TextEditor/utils/extensions/LocalImageExtension.ts
+++ b/src/components/common/TextEditor/utils/extensions/LocalImageExtension.ts
@@ -7,7 +7,12 @@ export interface LocalImageOptions {
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     localImage: {
-      insertLocalImage: (attrs: { src: string; alt?: string }) => ReturnType;
+      insertLocalImage: (attrs: {
+        src: string;
+        alt?: string;
+        width: number;
+        height: number;
+      }) => ReturnType;
     };
   }
 }
@@ -23,6 +28,8 @@ export const LocalImageExtension = Node.create<LocalImageOptions>({
     return {
       src: { default: null },
       alt: { default: null },
+      width: { default: null },
+      height: { default: null },
     };
   },
 
@@ -35,6 +42,8 @@ export const LocalImageExtension = Node.create<LocalImageOptions>({
           return {
             src: img?.getAttribute('src'),
             alt: img?.getAttribute('alt') ?? '',
+            width: img?.getAttribute('width') ? parseInt(img.getAttribute('width')!) : null,
+            height: img?.getAttribute('height') ? parseInt(img.getAttribute('height')!) : null,
           };
         },
       },
@@ -60,10 +69,11 @@ export const LocalImageExtension = Node.create<LocalImageOptions>({
   },
 
   addNodeView() {
-    return ({ node }) => {
+    return ({ node, getPos, editor }) => {
       const outer = document.createElement('div');
       outer.className = 'image-outer-wrapper';
       outer.setAttribute('data-image-outer', '');
+      outer.contentEditable = 'false';
 
       const inner = document.createElement('div');
       inner.className = 'image-inner-wrapper';
@@ -72,12 +82,77 @@ export const LocalImageExtension = Node.create<LocalImageOptions>({
       const img = document.createElement('img');
       img.setAttribute('src', node.attrs.src);
       if (node.attrs.alt) img.setAttribute('alt', node.attrs.alt);
+      if (node.attrs.width) img.style.width = `${node.attrs.width}px`;
+      if (node.attrs.height) img.style.height = `${node.attrs.height}px`;
 
+      const resizeHandle = document.createElement('div');
+      resizeHandle.className = 'resize-handle';
+      resizeHandle.style.position = 'absolute';
+      resizeHandle.style.right = '0';
+      resizeHandle.style.bottom = '0';
+      resizeHandle.style.width = '12px';
+      resizeHandle.style.height = '12px';
+      resizeHandle.style.background = 'rgba(0, 0, 0, 0.4)';
+      resizeHandle.style.cursor = 'nwse-resize';
+
+      inner.style.position = 'relative';
       inner.appendChild(img);
+      inner.appendChild(resizeHandle);
       outer.appendChild(inner);
+
+      // Resize 이벤트 로직
+      let startX = 0;
+      let startY = 0;
+      let startWidth = 0;
+      let startHeight = 0;
+
+      const handleMouseDown = (event: MouseEvent) => {
+        event.preventDefault();
+        startX = event.clientX;
+        startY = event.clientY;
+        startWidth = img.offsetWidth;
+        startHeight = img.offsetHeight;
+
+        document.addEventListener('mousemove', handleMouseMove);
+        document.addEventListener('mouseup', handleMouseUp);
+      };
+
+      const handleMouseMove = (event: MouseEvent) => {
+        const dx = event.clientX - startX;
+        const dy = event.clientY - startY;
+        const newWidth = Math.max(50, startWidth + dx);
+        const newHeight = Math.max(50, startHeight + dy);
+
+        img.style.width = `${newWidth}px`;
+        img.style.height = `${newHeight}px`;
+      };
+
+      const handleMouseUp = () => {
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+
+        const newWidth = img.offsetWidth;
+        const newHeight = img.offsetHeight;
+
+        // 실제 Node 속성 업데이트
+        const pos = getPos?.();
+        if (typeof pos === 'number') {
+          editor.commands.command(({ tr }) => {
+            tr.setNodeMarkup(pos, undefined, {
+              ...node.attrs,
+              width: newWidth,
+              height: newHeight,
+            });
+            return true;
+          });
+        }
+      };
+
+      resizeHandle.addEventListener('mousedown', handleMouseDown);
 
       return {
         dom: outer,
+        contentDOM: null,
       };
     };
   },

--- a/src/components/common/TextEditor/utils/handlers/handleImageSelect.ts
+++ b/src/components/common/TextEditor/utils/handlers/handleImageSelect.ts
@@ -17,11 +17,16 @@ export const handleImageSelect = (
 
   const img = new Image();
 
-  const editorWidth = editor.view.dom.clientWidth;
+  const { from } = editor.state.selection;
+  const domAtPos = editor.view.domAtPos(from);
+  const container = (domAtPos.node as HTMLElement)?.closest?.(
+    '[data-node-view-wrapper], .ProseMirror > *',
+  ) as HTMLElement;
+  const containerWidth = container?.clientWidth ?? editor.view.dom.clientWidth;
 
   img.onload = () => {
     const aspectRatio = img.naturalWidth / img.naturalHeight;
-    const nextWidth = editorWidth < img.naturalWidth ? editorWidth : img.naturalWidth;
+    const nextWidth = containerWidth < img.naturalWidth ? containerWidth : img.naturalWidth;
     const nextHeight = nextWidth / aspectRatio;
 
     editor

--- a/src/components/common/TextEditor/utils/handlers/handleImageSelect.ts
+++ b/src/components/common/TextEditor/utils/handlers/handleImageSelect.ts
@@ -15,14 +15,29 @@ export const handleImageSelect = (
     [imageBlobURL]: file,
   }));
 
-  editor
-    ?.chain()
-    .focus()
-    .insertLocalImage({
-      src: imageBlobURL,
-      alt: file.name,
-    })
-    .run();
+  const img = new Image();
+
+  const editorWidth = editor.view.dom.clientWidth;
+  const aspectRatio = img.naturalWidth / img.naturalHeight;
+  const nextWidth = editorWidth < img.naturalWidth ? editorWidth : img.naturalWidth;
+  const nextHeight = nextWidth / aspectRatio;
+
+  img.onload = () => {
+    console.log(img.naturalHeight);
+    console.log(img.naturalWidth);
+    editor
+      ?.chain()
+      .focus()
+      .insertLocalImage({
+        src: imageBlobURL,
+        alt: file.name,
+        width: nextWidth,
+        height: nextHeight,
+      })
+      .run();
+  };
+
+  img.src = imageBlobURL;
 
   e.target.value = '';
 };

--- a/src/components/common/TextEditor/utils/handlers/handleImageSelect.ts
+++ b/src/components/common/TextEditor/utils/handlers/handleImageSelect.ts
@@ -18,13 +18,12 @@ export const handleImageSelect = (
   const img = new Image();
 
   const editorWidth = editor.view.dom.clientWidth;
-  const aspectRatio = img.naturalWidth / img.naturalHeight;
-  const nextWidth = editorWidth < img.naturalWidth ? editorWidth : img.naturalWidth;
-  const nextHeight = nextWidth / aspectRatio;
 
   img.onload = () => {
-    console.log(img.naturalHeight);
-    console.log(img.naturalWidth);
+    const aspectRatio = img.naturalWidth / img.naturalHeight;
+    const nextWidth = editorWidth < img.naturalWidth ? editorWidth : img.naturalWidth;
+    const nextHeight = nextWidth / aspectRatio;
+
     editor
       ?.chain()
       .focus()


### PR DESCRIPTION
# 📜 작업 내용
textEditor의 하단을 클릭해도 editor에 focus 되도록 하는 기능을 추가하였습니다.

이전 PR내용이 포함되어있으므로, 아래 커밋을 확인해주세요.
https://github.com/Chiman2937/team1-w1k1ed-project/commit/3368db5a0e58376bb91dbce6cfcd6ae9cb1fe52b

@3rdflr 해당 내용 merge 시 addboard page에 자동 반영됩니다.

## 💡 EditorClickCatcher.tsx
해당 컴포넌트에 클릭 이벤트 발생 시 Editor 컴포넌트로 커서가 이동됩니다.

ContentEditor.tsx에 해당 컴포넌트가 포함되어있으며,
ContentEditor 컴포넌트를 감싸는 부모 컴포넌트의 높이가 명확히 지정되어있어야 EditorClickCatcher가 정상 작동합니다.

```ts
//doesn't work
<div className='min-h-48'>
  <ContentEditor editor={editor} />
</div>
```
```ts
//recommended
<div className='h-48'>
  <ContentEditor editor={editor} />
</div>
```

## 💡 작업 결과물
![Animation](https://github.com/user-attachments/assets/b533eef9-6f30-4b9d-a504-2cb21628bc05)
