### PR TITLE
feat: 위키 상세페이지 위키 질문/답변 수정 기능 추가(내 프로필일 때만)

### DIFF
--- a/src/components/page/wikicode/ProfileCard/ProfileCard.tsx
+++ b/src/components/page/wikicode/ProfileCard/ProfileCard.tsx
@@ -61,7 +61,7 @@ const ProfileCard = ({ wikiData }: Props) => {
 
           'lg:w-full py-[20px] grow',
           'px-[20px]',
-          'xs:px-0',
+          'xs:pl-0',
           'lg:px-[20px]',
           'min-w-[200px]',
           'md:min-w-[250px]',

--- a/src/components/page/wikicode/ProfileIndex/ProfileIndex.tsx
+++ b/src/components/page/wikicode/ProfileIndex/ProfileIndex.tsx
@@ -1,3 +1,4 @@
+import { useWikiContext } from '@/context/WikiContext';
 import clsx from 'clsx';
 
 interface IndexItem {
@@ -10,6 +11,8 @@ interface Props {
 }
 
 const ProfileIndex = ({ indexList }: Props) => {
+  const { isEditing } = useWikiContext();
+  if (!isEditing) return null;
   return (
     <div
       className={clsx(

--- a/src/components/page/wikicode/ProfileQnAEditor/ProfileQnAEditor.tsx
+++ b/src/components/page/wikicode/ProfileQnAEditor/ProfileQnAEditor.tsx
@@ -1,0 +1,60 @@
+import { GetProfileItemResponse } from '@/api/profile/getProfileAPI';
+import { useWikiContext } from '@/context/WikiContext';
+import { ChangeEvent } from 'react';
+import ProfileField from '../ProfileCard/components/ProfileField';
+import clsx from 'clsx';
+import { useAuthContext } from '@/context/AuthContext';
+
+interface Props {
+  wikiData: GetProfileItemResponse;
+}
+
+const ProfileQnAEditor = ({ wikiData }: Props) => {
+  const { wikiProfile, setWikiProfile, isEditing, editingInfo } = useWikiContext();
+  const { user } = useAuthContext();
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const id = e.target.id as keyof GetProfileItemResponse;
+    const value = e.target.value;
+    setWikiProfile((prev) => {
+      if (!prev) return null;
+      return {
+        ...prev,
+        [id]: value,
+      };
+    });
+  };
+
+  // 프로필 수정가능 조건
+  const editCondition =
+    isEditing === true && // 1. 수정 모드 진입한 경우
+    editingInfo?.userId === user?.id && // 2. 현재 수정 등록된 userId와 나의 userId가 동일 할 경우
+    user?.profile?.id === wikiData?.id; // 3. 나의 profileId와 wiki 페이지의 profileId가 동일한 경우
+
+  if (!wikiProfile) return;
+  if (!editCondition) return;
+  return (
+    <div className='py-[20px] border-t-1 border-gray-200'>
+      <div className={clsx('flex flex-col gap-[20px] max-w-[400px]')}>
+        <ProfileField>
+          <ProfileField.label>위키 질문</ProfileField.label>
+          <ProfileField.input
+            id='securityQuestion'
+            value={wikiProfile?.securityQuestion}
+            onChange={handleInputChange}
+          />
+        </ProfileField>
+        <ProfileField>
+          <ProfileField.label>위키 답변</ProfileField.label>
+          <ProfileField.input
+            id='securityAnswer'
+            value={wikiProfile?.securityAnswer}
+            onChange={handleInputChange}
+          />
+        </ProfileField>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileQnAEditor;

--- a/src/components/page/wikicode/WikiDetailSection.tsx
+++ b/src/components/page/wikicode/WikiDetailSection.tsx
@@ -18,6 +18,7 @@ import WikiInfo from './WikiInfo/WikiInfo';
 import { ToastRender } from 'cy-toast';
 import { useRouter } from 'next/navigation';
 import { useUnloadAlert } from '@/hooks/useUnloadAlert';
+import ProfileQnAEditor from './ProfileQnAEditor/ProfileQnAEditor';
 
 interface Props {
   wikiData: GetProfileItemResponse;
@@ -112,6 +113,7 @@ const WikiDetailSection = ({ wikiData }: Props) => {
         wikiData={wikiData}
       />
       <WikiInfo onTimerFinish={onTimerFinish} />
+      <ProfileQnAEditor wikiData={wikiData} />
       <div
         className={clsx(
           'border-y-1 border-gray-200',
@@ -119,6 +121,7 @@ const WikiDetailSection = ({ wikiData }: Props) => {
           'w-full py-[20px]',
           'sm:flex-row',
           'xl:py-0 xl:border-0',
+          'lg:py-0 lg:border-b-0',
         )}
       >
         <ProfileIndex indexList={getHtmlHeadings(wikiData.content)} />


### PR DESCRIPTION
# 📜 작업 내용

## ProfileQnAEditor.tsx

위키 질문/답변 수정이 가능한 컴포넌트입니다.
해당 컴포넌트는 wikiContext의 isEditing이 true일 때만 mount 됩니다.

디자인 관련 수정사항은 #89 에 남겨주시거나, 디스코드로 말씀 부탁드립니다!

## 💡 내 프로필/다른 사람 프로필 ui 비교
<img width="1054" height="492" alt="image" src="https://github.com/user-attachments/assets/11fa0438-ad2b-4c1c-a4d6-379264723dfa" />

## 💡 결과물
![Animation](https://github.com/user-attachments/assets/3b0490bd-e16e-4ce9-96df-c497e76a21cb)
