### PR TITLE
feat: 위키 상세페이지 프로필 이미지 선택 및 업로드(수정) 기능 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,12 @@ const nextConfig: NextConfig = {
         port: '', // 포트가 없다면 빈 문자열
         pathname: '/Wikied/user/**', // 또는 /Wikied/**, /Wikied/user/1429/** 등 더 구체적으로 지정 가능
       },
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+        port: '', // 포트가 없다면 빈 문자열
+        pathname: '/dxho7f5dm/image/upload/**', // 또는 /Wikied/**, /Wikied/user/1429/** 등 더 구체적으로 지정 가능
+      },
       // },
     ],
   },

--- a/src/components/page/wikicode/ProfileCard/ProfileCard.tsx
+++ b/src/components/page/wikicode/ProfileCard/ProfileCard.tsx
@@ -1,10 +1,11 @@
 import clsx from 'clsx';
 import { GetProfileItemResponse } from '@/api/profile/getProfileAPI';
 import { useWikiContext } from '@/context/WikiContext';
-import Image from 'next/image';
 import ProfileItemListViewer from './components/ProfileItemListViewer';
 import ProfileItemListEditor from './components/ProfileItemListEditor';
 import { useAuthContext } from '@/context/AuthContext';
+import ProfileImageViewer from './components/ProfileImageViewer';
+import ProfileImageEditor from './components/ProfileImageEditor';
 
 interface Props {
   wikiData: GetProfileItemResponse;
@@ -37,7 +38,7 @@ const ProfileCard = ({ wikiData }: Props) => {
         className={clsx(
           // 'lg:bg-white lg:border-1 lg:border-gray-300',
           'relative flex flex-col gap-[5px]',
-          'pt-[20px] px-[20px]',
+          'pt-[40px] px-[40px]',
           'w-full',
           'xs:w-[150px]',
           'sm:w-[150px]',
@@ -45,9 +46,8 @@ const ProfileCard = ({ wikiData }: Props) => {
           'lg:w-full',
         )}
       >
-        <div className={clsx('rounded-full', 'relative aspect-square overflow-hidden', 'w-full')}>
-          <Image className='object-cover' src={wikiData.image} alt='프로필 이미지' layout='fill' />
-        </div>
+        {isEditing && <ProfileImageEditor imageUrl={wikiData.image} />}
+        {!isEditing && <ProfileImageViewer imageUrl={wikiData.image} />}
         <div className='text-center w-full'>
           <p className='text-xl-semibold text-grayscale-500'>
             {wikiData.name}

--- a/src/components/page/wikicode/ProfileCard/ProfileCard.tsx
+++ b/src/components/page/wikicode/ProfileCard/ProfileCard.tsx
@@ -40,21 +40,23 @@ const ProfileCard = ({ wikiData }: Props) => {
           'relative flex flex-col gap-[5px]',
           'pt-[40px] px-[40px]',
           'w-full',
-          'xs:w-[150px]',
-          'sm:w-[150px]',
-          'md:w-[200px]',
+          'xs:w-[200px]',
+          'sm:w-[250px]',
+          'md:w-[250px]',
           'lg:w-full',
         )}
       >
         {isEditing && <ProfileImageEditor imageUrl={wikiData.image} />}
         {!isEditing && <ProfileImageViewer imageUrl={wikiData.image} />}
+      </div>
+      {!isEditing && (
         <div className='text-center w-full'>
           <p className='text-xl-semibold text-grayscale-500'>
             {wikiData.name}
             <span className='text-lg-semibold text-grayscale-400'>{` (${wikiData.nickname})`}</span>
           </p>
         </div>
-      </div>
+      )}
       <div
         className={clsx(
           // 'lg:bg-white lg:border-1 lg:border-gray-300',

--- a/src/components/page/wikicode/ProfileCard/ProfileCard.tsx
+++ b/src/components/page/wikicode/ProfileCard/ProfileCard.tsx
@@ -49,14 +49,6 @@ const ProfileCard = ({ wikiData }: Props) => {
         {isEditing && <ProfileImageEditor imageUrl={wikiData.image} />}
         {!isEditing && <ProfileImageViewer imageUrl={wikiData.image} />}
       </div>
-      {!isEditing && (
-        <div className='text-center w-full'>
-          <p className='text-xl-semibold text-grayscale-500'>
-            {wikiData.name}
-            <span className='text-lg-semibold text-grayscale-400'>{` (${wikiData.nickname})`}</span>
-          </p>
-        </div>
-      )}
       <div
         className={clsx(
           // 'lg:bg-white lg:border-1 lg:border-gray-300',

--- a/src/components/page/wikicode/ProfileCard/components/ProfileImageEditor.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileImageEditor.tsx
@@ -1,0 +1,66 @@
+import clsx from 'clsx';
+import Image from 'next/image';
+import { useCallback, useRef, useState } from 'react';
+import { FiCamera as IconCamera } from 'react-icons/fi';
+import { TiDelete as IconDelete } from 'react-icons/ti';
+interface Props {
+  imageUrl: string;
+}
+
+const ProfileImageEditor = ({ imageUrl }: Props) => {
+  const [blob, setBlob] = useState('');
+  const [_file, setFile] = useState<File | null>(null);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const addImage = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const imageBlobURL = URL.createObjectURL(file);
+    if (blob) URL.revokeObjectURL(blob);
+    setBlob(imageBlobURL);
+    setFile(file);
+    e.target.value = '';
+  };
+
+  const handleImageDelete = () => {
+    setBlob('');
+    setFile(null);
+  };
+
+  return (
+    <div className='relative aspect-square w-full'>
+      <div className={clsx('relative rounded-full overflow-hidden', 'w-full h-full')}>
+        <Image className='object-cover' src={blob || imageUrl} alt='프로필 이미지' layout='fill' />
+        <div
+          className={clsx('w-full h-full opacity-30 bg-black', 'cursor-pointer')}
+          onClick={addImage}
+        />
+        <div className='absolute opacity-80 text-white top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%] aspect-square w-1/5 pointer-events-none'>
+          <IconCamera className='w-full h-full' />
+        </div>
+        <input ref={inputRef} className='hidden' type='file' onChange={handleInputChange} />
+      </div>
+      {blob && (
+        <div
+          className={clsx(
+            'absolute top-[5%] right-[5%] z-1',
+            'aspect-square w-1/5',
+            'rounded-full ',
+            'bg-white',
+          )}
+          onClick={handleImageDelete}
+        >
+          <IconDelete className='w-full h-full text-gray-400 hover:text-gray-500 cursor-pointer' />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProfileImageEditor;

--- a/src/components/page/wikicode/ProfileCard/components/ProfileImageViewer.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileImageViewer.tsx
@@ -1,0 +1,16 @@
+import clsx from 'clsx';
+import Image from 'next/image';
+
+interface Props {
+  imageUrl: string;
+}
+
+const ProfileImageViewer = ({ imageUrl }: Props) => {
+  return (
+    <div className={clsx('rounded-full', 'relative aspect-square overflow-hidden', 'w-full')}>
+      <Image className='object-cover' src={imageUrl} alt='프로필 이미지' layout='fill' />
+    </div>
+  );
+};
+
+export default ProfileImageViewer;

--- a/src/components/page/wikicode/ProfileIndex/ProfileIndex.tsx
+++ b/src/components/page/wikicode/ProfileIndex/ProfileIndex.tsx
@@ -12,7 +12,9 @@ interface Props {
 
 const ProfileIndex = ({ indexList }: Props) => {
   const { isEditing } = useWikiContext();
-  if (!isEditing) return null;
+
+  if (isEditing) return null;
+
   return (
     <div
       className={clsx(

--- a/src/components/page/wikicode/WikiDetailSection.tsx
+++ b/src/components/page/wikicode/WikiDetailSection.tsx
@@ -19,13 +19,21 @@ import { ToastRender } from 'cy-toast';
 import { useRouter } from 'next/navigation';
 import { useUnloadAlert } from '@/hooks/useUnloadAlert';
 import ProfileQnAEditor from './ProfileQnAEditor/ProfileQnAEditor';
+import { uploadFileAPI } from '@/api/uploadFileAPI';
 
 interface Props {
   wikiData: GetProfileItemResponse;
 }
 
 const WikiDetailSection = ({ wikiData }: Props) => {
-  const { wikiProfile, setWikiProfile, setIsEditing, isEditing, setEditingInfo } = useWikiContext();
+  const {
+    wikiProfile,
+    setWikiProfile,
+    setIsEditing,
+    isEditing,
+    setEditingInfo,
+    tempProfileImageFile,
+  } = useWikiContext();
 
   //textEditor 인스턴스 객체 호출
   const { editor, tempFiles, setTempFiles } = useTextEditor({
@@ -55,10 +63,15 @@ const WikiDetailSection = ({ wikiData }: Props) => {
   const handleUpdateProfileSubmit = async () => {
     if (!editor) return;
     if (!wikiProfile) return;
+    let nextProfileImage = wikiProfile.image;
+    if (!!tempProfileImageFile) {
+      nextProfileImage = await uploadFileAPI({ fileObject: tempProfileImageFile, type: 'image' });
+    }
     const nextContent = await handlehtmlParse({ editor, files: tempFiles });
     const nextWikiProfile = {
       ...wikiProfile,
       content: nextContent,
+      image: nextProfileImage,
     };
     await patchProfileItemAPI({ code: wikiData.code, params: nextWikiProfile });
     setIsEditing(false);
@@ -121,7 +134,7 @@ const WikiDetailSection = ({ wikiData }: Props) => {
           'w-full py-[20px]',
           'sm:flex-row',
           'xl:py-0 xl:border-0',
-          'lg:py-0 lg:border-b-0',
+          'lg:border-b-0',
         )}
       >
         <ProfileIndex indexList={getHtmlHeadings(wikiData.content)} />

--- a/src/context/WikiContext.tsx
+++ b/src/context/WikiContext.tsx
@@ -10,6 +10,8 @@ interface WikiProfileContextType {
   setEditingInfo: React.Dispatch<React.SetStateAction<GetProfilePingResponse | null>>;
   isEditing: boolean;
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
+  tempProfileImageFile: File | null;
+  setTempProfileImageFile: React.Dispatch<React.SetStateAction<File | null>>;
 }
 
 const wikiContext = createContext<WikiProfileContextType | null>(null);
@@ -26,6 +28,8 @@ export const WikiProvider = ({ children }: ProviderProps) => {
   // 내가 퀴즈를 맞추면 수정모드로 진입
   const [isEditing, setIsEditing] = useState(false);
 
+  const [tempProfileImageFile, setTempProfileImageFile] = useState<File | null>(null);
+
   return (
     <wikiContext.Provider
       value={{
@@ -35,6 +39,8 @@ export const WikiProvider = ({ children }: ProviderProps) => {
         setEditingInfo,
         isEditing,
         setIsEditing,
+        tempProfileImageFile,
+        setTempProfileImageFile,
       }}
     >
       {children}


### PR DESCRIPTION
# 📜 작업 내용

- 위키 상세 페이지에서 프로필 이미지를 선택 후, 이미지 업로드를 통해 프로필을 수정하는 기능을 구현하였습니다. (#89)
- 프로필 이미지의 크기를 더 작게 수정하였습니다.(#89) @canofmato
- next.config.js에 cloudinary 이미지 경로를 추가하였습니다.

## 💡 작업 결과물
![Animation](https://github.com/user-attachments/assets/43f8c427-034e-4ada-a8f7-0351229a3b94)

![Animation](https://github.com/user-attachments/assets/2bad4c7a-957b-46ea-b222-73f2cee7f9fb)
