### PR TITLE
feat: 자유게시판 게시글 내 토스트 추가 및 404에러, 에러 페이지 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4187,6 +4187,13 @@
         "webpack": "^5"
       }
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -7798,6 +7805,38 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/happy-dom": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-18.0.1.tgz",
+      "integrity": "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/@types/node": {
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -11859,7 +11898,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12216,6 +12255,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {

--- a/src/app/addboard/page.tsx
+++ b/src/app/addboard/page.tsx
@@ -60,6 +60,7 @@ const AddBoard = () => {
       }
       setIsSubmitting(true);
       const response = await postArticle(formData);
+      if (response.id === undefined) throw new Error();
       toast.run(({ isClosing, isOpening, index }) => (
         <SnackBar variant='success' isOpening={isOpening} isClosing={isClosing} index={index}>
           게시물 작성에 성공했습니다.

--- a/src/app/addboard/page.tsx
+++ b/src/app/addboard/page.tsx
@@ -77,7 +77,7 @@ const AddBoard = () => {
       ));
       setTimeout(() => {
         router.push('/error');
-      }, 2000);
+      }, 1500);
     } finally {
       setIsSubmitting(false);
       setIsModalOpen(false);

--- a/src/app/boards/[id]/page.tsx
+++ b/src/app/boards/[id]/page.tsx
@@ -6,6 +6,7 @@ import BoardDetail from '@/components/page/boardDetail/BoardDetail';
 import { useAuthContext } from '@/context/AuthContext';
 import { useParams } from 'next/navigation';
 import Animation from '@/components/common/Animation';
+import { ToastRender } from 'cy-toast';
 
 const Board = () => {
   const param = useParams();
@@ -17,6 +18,7 @@ const Board = () => {
   return (
     <>
       <Animation>
+        <ToastRender />
         <BoardDetail id={id} userId={userId} isAuthenticated={isAuthenticated}></BoardDetail>
         <BoardComments id={id} userId={userId} isAuthenticated={isAuthenticated}></BoardComments>
       </Animation>

--- a/src/app/error/page.tsx
+++ b/src/app/error/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { motion, Variants, Transition } from 'framer-motion';
+import { FaExclamationTriangle as Exclamation } from 'react-icons/fa';
+import Link from 'next/link';
+
+const dropVariants: Variants = {
+  initial: {
+    y: -100,
+    opacity: 0,
+  },
+  animate: {
+    y: 0,
+    opacity: 1,
+  },
+};
+
+const ErrorPage = () => {
+  const numbers = ['E', 'R', 'R', 'O', 'R', '!'];
+
+  const baseTransition: Transition = {
+    type: 'spring',
+    damping: 10,
+    stiffness: 100,
+    duration: 0.8,
+  };
+
+  return (
+    <div className='flex flex-col items-center justify-center min-h-screen text-white bg-grayscale-50 overflow-hidden'>
+      <Exclamation className='text-yellow-400 text-9xl mb-8 animate-pulse' />
+      <div className='flex space-x-2 text-8xl font-bold'>
+        {numbers.map((num, index) => (
+          <motion.div
+            key={index}
+            variants={dropVariants}
+            initial='initial'
+            animate='animate'
+            transition={{
+              ...baseTransition,
+              delay: index * 0.1,
+            }}
+            className='text-red-500 animate-pulse'
+          >
+            {num}
+          </motion.div>
+        ))}
+      </div>
+
+      <div className='flex mt-8 text-2xl text-gray-500 text-2lg-semibold gap-5'>
+        뭔가 잘못되었습니다.
+      </div>
+      <p className='mt-4 text-lg text-gray-500'>
+        다른 페이지에 접속하거나, 재 로그인 후 다시 시도해주세요.
+      </p>
+      <div className='flex gap-8'>
+        <Link
+          href='/'
+          className='text-red-500 my-10 border-2 border-red-500 rounded-xl py-2 px-6 text-md-semibold hover:text-gray-50 hover:bg-red-500'
+        >
+          메인 페이지로 이동
+        </Link>
+        <Link
+          href='https://github.com/Chiman2937/team1-w1k1ed-project/issues/new'
+          target='_blank'
+          className='text-red-500 my-10 border-2 border-red-500 rounded-xl py-2 px-6 text-md-semibold hover:text-gray-50 hover:bg-red-500'
+        >
+          깃허브에 이슈 남기기
+        </Link>
+      </div>
+    </div>
+  );
+};
+export default ErrorPage;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -153,6 +153,11 @@
   }
 }
 
+html {
+  scrollbar-color: var(--primary-200) transparent;
+  scrollbar-width: thin;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { motion, Variants, Transition } from 'framer-motion';
+import Link from 'next/link';
+
+const dropVariants: Variants = {
+  initial: {
+    y: -100,
+    opacity: 0,
+  },
+  animate: {
+    y: 0,
+    opacity: 1,
+  },
+};
+
+const NotFound = () => {
+  const numbers = ['4', '0', '4'];
+
+  const baseTransition: Transition = {
+    type: 'spring',
+    damping: 10,
+    stiffness: 100,
+    duration: 0.8,
+  };
+
+  return (
+    <div className='flex flex-col items-center justify-center min-h-screen bg-grayscale-50 text-white overflow-hidden'>
+      <div className='flex space-x-4 text-9xl font-extrabold'>
+        {numbers.map((num, index) => (
+          <motion.div
+            key={index}
+            variants={dropVariants}
+            initial='initial'
+            animate='animate'
+            transition={{
+              ...baseTransition,
+              delay: index * 0.2,
+            }}
+            className='text-primary-green-200 animate-pulse'
+          >
+            {num}
+          </motion.div>
+        ))}
+      </div>
+      <div className='flex mt-8 text-2xl text-gray-500'>페이지를 찾을 수 없습니다.</div>
+      <p className='mt-4 text-lg text-gray-500'>주소가 올바른지 확인해 주세요.</p>
+      <Link
+        href='/'
+        className='text-primary-green-200 m-10 border border-primary-green-200 rounded-2xl py-1 px-6 hover:text-gray-50 hover:bg-primary-green-200'
+      >
+        홈으로
+      </Link>
+    </div>
+  );
+};
+export default NotFound;

--- a/src/components/page/boardDetail/BoardComment.tsx
+++ b/src/components/page/boardDetail/BoardComment.tsx
@@ -14,6 +14,8 @@ import { FiEdit2 as Edit } from 'react-icons/fi';
 import { FaRegTrashAlt as Delete } from 'react-icons/fa';
 import CommentEdit from './CommentEdit';
 import Button from '@/components/common/Button';
+import { toast } from 'cy-toast';
+import SnackBar from '@/components/common/Snackbar';
 
 interface CommentItemProps {
   id: number | undefined;
@@ -32,10 +34,19 @@ const BoardComment = ({ id, comment, onDelete, onUpdate }: CommentItemProps) => 
     try {
       await deleteComment(comment.id);
       onDelete(comment.id);
-      // 댓글이 삭제되었습니다 토스트
+      toast.run(({ isClosing, isOpening, index }) => (
+        <SnackBar variant='success' isOpening={isOpening} isClosing={isClosing} index={index}>
+          댓글이 삭제되었습니다.
+        </SnackBar>
+      ));
     } catch (error) {
       console.log(error);
-      router.push('/500');
+      toast.run(({ isClosing, isOpening, index }) => (
+        <SnackBar variant='error' isOpening={isOpening} isClosing={isClosing} index={index}>
+          댓글 삭제에 실패했습니다.
+        </SnackBar>
+      ));
+      router.push('/error');
     }
   };
 

--- a/src/components/page/boardDetail/BoardComments.tsx
+++ b/src/components/page/boardDetail/BoardComments.tsx
@@ -7,6 +7,8 @@ import { getComment, postComment } from '@/api/articleApi';
 import { useRef, useState, useEffect, useCallback } from 'react';
 import LoadingSpinner from '@/components/common/LoadingSpinner/LoadingSpinner';
 import { FaCommentDots as CommentImg } from 'react-icons/fa';
+import { toast } from 'cy-toast';
+import SnackBar from '@/components/common/Snackbar';
 
 export interface CommentWriterResponse {
   image: string;
@@ -73,7 +75,7 @@ const BoardComments = ({
       setIsCommentLoading(true);
       const response = await getComment(id, LIMIT, cursor);
       setComments((prev) => {
-        if (prev === response.list) return prev;
+        if (prev == response.list) return [...prev];
         return [...prev, ...response.list];
       });
       setCursor(response.nextCursor);
@@ -105,12 +107,21 @@ const BoardComments = ({
         });
         getAllComment();
       } else {
-        // 토스트 추가
+        toast.run(({ isClosing, isOpening, index }) => (
+          <SnackBar variant='error' isOpening={isOpening} isClosing={isClosing} index={index}>
+            로그인 후 이용해 주시길 바랍니다.
+          </SnackBar>
+        ));
         router.push('/login');
       }
     } catch (e) {
-      // 댓글 작성 오류 토스트
       console.log(e);
+      toast.run(({ isClosing, isOpening, index }) => (
+        <SnackBar variant='error' isOpening={isOpening} isClosing={isClosing} index={index}>
+          댓글 작성에 실패했습니다.
+        </SnackBar>
+      ));
+      router.push('/error');
     }
   };
 
@@ -124,6 +135,11 @@ const BoardComments = ({
   };
 
   const handleCommentUpdated = (updatedComment: CommentResponse) => {
+    toast.run(({ isClosing, isOpening, index }) => (
+      <SnackBar variant='success' isOpening={isOpening} isClosing={isClosing} index={index}>
+        댓글 수정이 완료되었습니다.
+      </SnackBar>
+    ));
     setComments((prevData) => {
       return prevData.map((comment) => {
         return comment.id === updatedComment.id ? updatedComment : comment;
@@ -151,11 +167,11 @@ const BoardComments = ({
     >
       <BoardTextArea
         count={commentCount}
-        isLogin={isAuthenticated}
+        isAuthenticated={isAuthenticated}
         onSubmit={handleCommentSubmit}
       />
       {commentCount === 0 ? (
-        <div className='flex flex-col justify-center items-center my-10'>
+        <div className='flex flex-col justify-center items-center mt-20'>
           <CommentImg size={170} className='text-primary-green-200 animation-bounce-comment' />
           <span className='my-5 text-grayscale-400'>댓글이 없습니다</span>
         </div>

--- a/src/components/page/boardDetail/BoardContent.tsx
+++ b/src/components/page/boardDetail/BoardContent.tsx
@@ -11,7 +11,12 @@ const BoardContent = ({ children }: { children: React.ReactNode }) => {
         {children}
       </div>
       <div className='flex items-center justify-center'>
-        <Button variant={'secondary'} className={'w-[140px] h-[45px] justify-center'}>
+        <Button
+          variant={'secondary'}
+          className={
+            'w-[140px] h-[45px] justify-center hover:bg-primary-green-200 hover:text-grayscale-50'
+          }
+        >
           <Link href={'/boards'}>목록으로</Link>
         </Button>
       </div>

--- a/src/components/page/boardDetail/BoardDetail.tsx
+++ b/src/components/page/boardDetail/BoardDetail.tsx
@@ -17,6 +17,8 @@ import Button from '@/components/common/Button';
 import { Modal } from 'react-simplified-package';
 import BoardSkeleton from './BoardSkeleton';
 import ContentViewer from '@/components/common/TextEditor/ContentViewer';
+import { toast } from 'cy-toast';
+import SnackBar from '@/components/common/Snackbar';
 
 const BoardDetail = ({
   id,
@@ -57,7 +59,11 @@ const BoardDetail = ({
   const handleLike = async () => {
     try {
       if (!isAuthenticated) {
-        //Toast 사용하기
+        toast.run(({ isClosing, isOpening, index }) => (
+          <SnackBar variant='error' isOpening={isOpening} isClosing={isClosing} index={index}>
+            로그인 후 이용해 주시길 바랍니다.
+          </SnackBar>
+        ));
         router.push('/login');
       }
       if (isLiked) {
@@ -75,19 +81,51 @@ const BoardDetail = ({
     }
   };
 
+  const handleDeleteModal = async () => {
+    if (!isAuthenticated) {
+      toast.run(({ isClosing, isOpening, index }) => (
+        <SnackBar variant='error' isOpening={isOpening} isClosing={isClosing} index={index}>
+          로그인 후 이용해 주시길 바랍니다.
+        </SnackBar>
+      ));
+      router.push('/login');
+    }
+    setIsModalOpen(true);
+  };
+
   const handleDelete = async () => {
     try {
       await deleteArticle(id);
-      // toast 삭제되었습니다
-      router.push('/boards');
+      toast.run(({ isClosing, isOpening, index }) => (
+        <SnackBar variant='success' isOpening={isOpening} isClosing={isClosing} index={index}>
+          게시물이 삭제되었습니다.
+        </SnackBar>
+      ));
+      setTimeout(() => {
+        router.push('/boards');
+      }, 1000);
     } catch (error) {
       console.log(error);
-      //toast 삭제 실패
+      toast.run(({ isClosing, isOpening, index }) => (
+        <SnackBar variant='error' isOpening={isOpening} isClosing={isClosing} index={index}>
+          게시물 삭제에 실패했습니다.
+        </SnackBar>
+      ));
       router.push('/error');
+    } finally {
+      setIsModalOpen(false);
     }
   };
 
   const handleEdit = () => {
+    if (!isAuthenticated) {
+      toast.run(({ isClosing, isOpening, index }) => (
+        <SnackBar variant='error' isOpening={isOpening} isClosing={isClosing} index={index}>
+          로그인 후 이용해 주시길 바랍니다.
+        </SnackBar>
+      ));
+      router.push('/login');
+    }
     setIsEditing(true);
   };
 
@@ -113,6 +151,7 @@ const BoardDetail = ({
       <Animation>
         <BoardContent>
           <BoardEdit
+            isEditing={isEditing}
             setIsEditing={setIsEditing}
             userName={name}
             id={id}
@@ -136,7 +175,7 @@ const BoardDetail = ({
                 {userId === writerId && (
                   <>
                     <BoardEditButton onEdit={handleEdit} />
-                    <BoardDeleteButton onDelete={() => setIsModalOpen(true)} />
+                    <BoardDeleteButton onDelete={handleDeleteModal} isEditing={isEditing} />
                   </>
                 )}
               </div>
@@ -147,6 +186,7 @@ const BoardDetail = ({
                 <p>{updatedDate}</p>
               </div>
               <BoardLikeButton
+                isAuthenticated={isAuthenticated}
                 initialLikeCount={likeCount}
                 onClick={handleLike}
                 isLiked={isLiked}

--- a/src/components/page/boardDetail/BoardDetail.tsx
+++ b/src/components/page/boardDetail/BoardDetail.tsx
@@ -103,7 +103,7 @@ const BoardDetail = ({
       ));
       setTimeout(() => {
         router.push('/boards');
-      }, 1000);
+      }, 1500);
     } catch (error) {
       console.log(error);
       toast.run(({ isClosing, isOpening, index }) => (

--- a/src/components/page/boardDetail/BoardDetailButton.tsx
+++ b/src/components/page/boardDetail/BoardDetailButton.tsx
@@ -11,9 +11,11 @@ import Button from '@/components/common/Button';
 interface ButtonsProps {
   onEdit?: () => void;
   onDelete?: () => void;
+  isEditing?: boolean;
 }
 
 interface LikeButtonProps {
+  isAuthenticated: boolean;
   initialLikeCount: number;
   onClick: () => void;
   isLiked: boolean;
@@ -35,11 +37,11 @@ export const BoardEditButton = ({ onEdit }: ButtonsProps) => {
   );
 };
 
-export const BoardDeleteButton = ({ onDelete }: ButtonsProps) => {
+export const BoardDeleteButton = ({ onDelete, isEditing }: ButtonsProps) => {
   return (
     <div>
       <Button className={'hidden md:inline w-[120px]'} onClick={() => onDelete?.()}>
-        삭제하기
+        {isEditing ? '삭제중..' : '삭제하기'}
       </Button>
       <button className='inline md:hidden' onClick={() => onDelete?.()}>
         <Delete className='text-grayscale-400' />
@@ -48,12 +50,18 @@ export const BoardDeleteButton = ({ onDelete }: ButtonsProps) => {
   );
 };
 
-export const BoardLikeButton = ({ initialLikeCount, onClick, isLiked }: LikeButtonProps) => {
+export const BoardLikeButton = ({
+  isAuthenticated,
+  initialLikeCount,
+  onClick,
+  isLiked,
+}: LikeButtonProps) => {
   return (
     <motion.div whileTap={{ scale: 1.5 }}>
       <button
         className={`flex justify-center items-center gap-[2px] ${isLiked && 'text-primary-green-200'}`}
         onClick={() => onClick()}
+        disabled={!isAuthenticated}
       >
         {isLiked ? (
           <FullHeart size={18} className=' text-primary-green-300' />

--- a/src/components/page/boardDetail/BoardTextArea.tsx
+++ b/src/components/page/boardDetail/BoardTextArea.tsx
@@ -2,22 +2,40 @@
 
 import { useState } from 'react';
 import Button from '@/components/common/Button';
+import { useRouter } from 'next/navigation';
+import { toast } from 'cy-toast';
+import SnackBar from '@/components/common/Snackbar';
 
 interface BoardTextAreaProps {
   count: number | undefined;
-  isLogin: boolean | undefined;
+  isAuthenticated: boolean | undefined;
   onSubmit: (formData: { content: string }) => void;
 }
 
 const MAX_CHARACTERS = 500;
 
-const BoardTextArea = ({ count, isLogin, onSubmit }: BoardTextAreaProps) => {
+const BoardTextArea = ({ count, isAuthenticated, onSubmit }: BoardTextAreaProps) => {
   const [content, setContent] = useState('');
   const [characterCount, setCharacterCount] = useState(0);
 
+  const router = useRouter();
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!isAuthenticated) {
+      toast.run(({ isClosing, isOpening, index }) => (
+        <SnackBar variant='error' isOpening={isOpening} isClosing={isClosing} index={index}>
+          로그인 후 이용해 주시길 바랍니다.
+        </SnackBar>
+      ));
+      router.push('/login');
+    }
     if (content.length <= MAX_CHARACTERS) {
+      toast.run(({ isClosing, isOpening, index }) => (
+        <SnackBar variant='success' isOpening={isOpening} isClosing={isClosing} index={index}>
+          댓글 작성에 성공했습니다.
+        </SnackBar>
+      ));
       await onSubmit({ content });
       setContent('');
       setCharacterCount(0);
@@ -29,11 +47,6 @@ const BoardTextArea = ({ count, isLogin, onSubmit }: BoardTextAreaProps) => {
     setCharacterCount(e.target.value.length);
   };
 
-  // const handleGuestRedirect = () => {
-  //   toast 알림
-  //   redirect
-  // };
-
   return (
     <>
       <div className='mt-20 text-lg-semibold lg:text-2lg-semibold'>
@@ -41,13 +54,15 @@ const BoardTextArea = ({ count, isLogin, onSubmit }: BoardTextAreaProps) => {
       </div>
       <form
         onSubmit={handleSubmit}
-        className='mt-3 h-[140px] min-w-[320px] bg-grayscale-100 p-5 rounded-lg'
+        className={`mt-3 h-[140px] min-w-[320px] bg-grayscale-100 p-5 rounded-lg
+        border-2 border-transparent ${isAuthenticated ? 'focus-within:border-primary-green-200' : 'focus-within:border-red-400'}
+        transition-colors duration-300 ease-in-out`}
       >
         <textarea
-          className='resize-none border-none outline-none h-[55%] w-full overflow-hidden bg-grayscale-100 text-grayscale-500'
+          className={`resize-none outline-none h-[55%] w-full overflow-hidden bg-grayscale-100 text-grayscale-500 ${isAuthenticated ? '' : 'focus:placeholder:text-red-400'}`}
           value={content}
           onChange={handleContentChange}
-          placeholder='댓글을 입력하세요.'
+          placeholder={isAuthenticated ? '댓글을 입력하세요.' : '로그인 후 이용해주세요.'}
           maxLength={MAX_CHARACTERS}
         />
 
@@ -58,7 +73,7 @@ const BoardTextArea = ({ count, isLogin, onSubmit }: BoardTextAreaProps) => {
           <div>
             <Button
               variant='primary'
-              disabled={characterCount > MAX_CHARACTERS || !content || !isLogin}
+              disabled={characterCount > MAX_CHARACTERS || !content || !isAuthenticated}
               type='submit'
             >
               댓글 작성


### PR DESCRIPTION
### 404 에러 페이지 


https://github.com/user-attachments/assets/1957adc4-bbfd-4842-86c8-75dd21bcd60f

next app router를 통해 404 에러 발생시 자동으로 해당 페이지로 리 다이렉팅 됩니다


### 그 외 에러 페이지


https://github.com/user-attachments/assets/54b3a2df-c95d-4f89-9de7-814f46bd9308

next app router의 error 페이지를 사용하려고 했으나 

app router는 핸들러 내부의 에러는 라우팅을 예외적으로 잡아내지 않는다는 사실...

그래서 부득이하게 /error 페이지로 이동해주는 경로를 생성해서 `router.push()` 를 통해 직접 이동 시켜줘야합니다

특정 권한이 없는경우 response.id 가 undefined가 되기 떄문에 

그때마다 에러를 발생시켜서 리 다이렉팅 해주고 있습니다


https://github.com/user-attachments/assets/a0a9c7d9-3e9a-4ec1-96e0-abaf3e9fa196


### 토스트 기능 추가 및 로그아웃 상태일때 인풋에 focus 추가


https://github.com/user-attachments/assets/2f9d06c9-6cb3-4858-99bd-f6393b064d89


https://github.com/user-attachments/assets/1a314f80-d134-4399-9675-12144f12a6bf



댓글 그리고 게시판을 추가 수정 삭제시 토스트가 추가되도록 했습니다

로그인 상태일때는 녹색 로그아웃 상태일때는 빨간색이 나오게 인풋을 수정했습니다 

### 스크롤바 색상 수정 

스크롤 바 색상을 녹색으로 수정 했습니다





