### PR TITLE
fix: 위키상세페이지 작성 완료 제출 시 페이지 새로고침되도록 수정

### DIFF
--- a/src/components/page/wikicode/WikiDetailSection.tsx
+++ b/src/components/page/wikicode/WikiDetailSection.tsx
@@ -16,7 +16,6 @@ import ProfileIndex from './ProfileIndex/ProfileIndex';
 import { getHtmlHeadings } from '@/components/common/TextEditor/utils/handlers/getHtmlHeadings';
 import WikiInfo from './WikiInfo/WikiInfo';
 import { ToastRender } from 'cy-toast';
-import { useRouter } from 'next/navigation';
 import { useUnloadAlert } from '@/hooks/useUnloadAlert';
 import ProfileQnAEditor from './ProfileQnAEditor/ProfileQnAEditor';
 import { uploadFileAPI } from '@/api/uploadFileAPI';
@@ -42,9 +41,7 @@ const WikiDetailSection = ({ wikiData }: Props) => {
 
   const [isExpiredModalOpen, setIsExpiredtModalOpen] = useState(false);
 
-  useUnloadAlert({ activeBy: isEditing });
-
-  const router = useRouter();
+  const { disable } = useUnloadAlert({ activeBy: isEditing });
 
   const onTimerFinish = useCallback(() => {
     setEditingInfo(null);
@@ -74,9 +71,8 @@ const WikiDetailSection = ({ wikiData }: Props) => {
       image: nextProfileImage,
     };
     await patchProfileItemAPI({ code: wikiData.code, params: nextWikiProfile });
-    setIsEditing(false);
-    setWikiProfile(null);
-    router.refresh();
+    disable();
+    window.location.reload();
   };
 
   // 수정 중 현황 정보 전역 state에 등록
@@ -92,21 +88,6 @@ const WikiDetailSection = ({ wikiData }: Props) => {
     };
     getProfilePing();
   }, [setEditingInfo, wikiData]);
-
-  // 새로고침/닫기 시 브라우저 확인창 띄우기
-  useEffect(() => {
-    if (!isEditing) return;
-
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      e.returnValue = ''; // 브라우저 기본 메시지 표시
-    };
-
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-    };
-  }, [isEditing]);
 
   if (!editor) return;
 

--- a/src/hooks/useUnloadAlert.tsx
+++ b/src/hooks/useUnloadAlert.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 interface Props {
   activeBy: boolean;
@@ -7,47 +7,57 @@ interface Props {
 
 export const useUnloadAlert = ({ activeBy }: Props) => {
   const router = useRouter();
+  const enabled = useRef(false);
 
-  // 새로고침/닫기 시 브라우저 확인창 띄우기
+  const handleBeforeUnload = useRef((e: BeforeUnloadEvent) => {
+    e.preventDefault();
+    e.returnValue = '';
+  });
+
+  const handleClick = useRef((e: Event) => {
+    e.preventDefault();
+    const targetElement = e.currentTarget as HTMLAnchorElement;
+    const targetAttr = targetElement.getAttribute('target');
+    if (targetAttr === '_blank') return;
+
+    const userConfirm = confirm(
+      '정말 이 페이지를 떠나시겠습니까?\n변경사항이 저장되지 않을 수 있습니다.',
+    );
+
+    if (userConfirm) {
+      const href = targetElement.getAttribute('href');
+      if (href) router.push(href);
+    }
+  });
+
   useEffect(() => {
     if (!activeBy) return;
 
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      e.returnValue = ''; // 브라우저 기본 메시지 표시
-    };
+    const beforeUnloadHandler = handleBeforeUnload.current;
+    const clickHandler = handleClick.current;
 
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-    };
-  }, [activeBy]);
-
-  useEffect(() => {
-    if (!activeBy) return;
+    window.addEventListener('beforeunload', beforeUnloadHandler);
     const navLinks = document.querySelectorAll('a');
+    navLinks.forEach((link) => link.addEventListener('click', clickHandler));
 
-    const handleClick = (e: Event) => {
-      e.preventDefault();
-      const targetElement = e.currentTarget as HTMLAnchorElement;
-      const targetAttr = targetElement.getAttribute('target');
-
-      if (targetAttr === '_blank') return;
-      const userConfirm = confirm(
-        '정말 이 페이지를 떠나시겠습니까?\n변경사항이 저장되지 않을 수 있습니다.',
-      );
-
-      if (userConfirm) {
-        const href = targetElement.getAttribute('href');
-        if (!href) return;
-        router.push(href);
-      }
-    };
-
-    navLinks.forEach((link) => link.addEventListener('click', handleClick));
+    enabled.current = true;
 
     return () => {
-      navLinks.forEach((link) => link.removeEventListener('click', handleClick));
+      window.removeEventListener('beforeunload', beforeUnloadHandler);
+      navLinks.forEach((link) => link.removeEventListener('click', clickHandler));
+      enabled.current = false;
     };
   }, [activeBy, router]);
+
+  const disable = () => {
+    if (!enabled.current) return;
+    window.removeEventListener('beforeunload', handleBeforeUnload.current);
+
+    const navLinks = document.querySelectorAll('a');
+    navLinks.forEach((link) => link.removeEventListener('click', handleClick.current));
+
+    enabled.current = false;
+  };
+
+  return { disable };
 };


### PR DESCRIPTION
# 📜 작업 내용

## 💡위키 상세 페이지
글 작성 제출 시 `router.refresh()`가 아닌 `window.location.reload()` 가 실행되도록 수정하였습니다.(새로고침)

## 💡useUnloadAlert

새로고침/닫기/페이지 이동 요청 시 경고를 띄우는 커스텀 훅에서
`글 작성 제출 시`에는 경고가 발생하지 않아야 하기 때문에
해당 기능을 disable 할 수 있는 함수를 반환하도록 수정하였습니다.

### 🔍 선언 방법
변경 전
```ts
  useUnloadAlert({ activeBy: isEditing });

```

변경 후
```ts
  const { disable } = useUnloadAlert({ activeBy: isEditing });
```

### 🔍 글 작성 제출 시 

```ts
  // 수정 업로드 이벤트
  const handleUpdateProfileSubmit = async () => {
    ....
    await patchProfileItemAPI({ code: wikiData.code, params: nextWikiProfile });
    disable(); // 이 함수를 통해 useUnloadAlert 비활성화하기
    window.location.reload();
  };
```