### PR TITLE
bugfix: 텍스트 에디터 뷰어 글자 겹치는 버그 수정

### DIFF
--- a/src/components/common/TextEditor/ContentViewer.tsx
+++ b/src/components/common/TextEditor/ContentViewer.tsx
@@ -5,6 +5,7 @@ import './viewer/viewerYoutubeStyle.css';
 import './viewer/viewerImageStyle.css';
 
 import DOMPurify from 'dompurify';
+import { getHtmlStringIsEmpty } from './utils/handlers/getHtmlStringIsEmpty';
 
 interface Props {
   content: string;
@@ -13,6 +14,10 @@ interface Props {
 const ContentViewer = ({ content }: Props) => {
   const htmlString = content;
   const sanitized = DOMPurify.sanitize(htmlString);
+
+  const isEmpty = getHtmlStringIsEmpty(content);
+
+  if (isEmpty) return null;
 
   return (
     <div>

--- a/src/components/common/TextEditor/utils/handlers/getHtmlStringIsEmpty.ts
+++ b/src/components/common/TextEditor/utils/handlers/getHtmlStringIsEmpty.ts
@@ -1,0 +1,28 @@
+import * as cheerio from 'cheerio';
+
+/**
+ * HTML 문자열이 실질적으로 "비어있는지" 판별
+ * - 텍스트가 없고
+ * - 내용 없는 p, br, 공백 문자만 있는 경우 true
+ */
+export const getHtmlStringIsEmpty = (html: string): boolean => {
+  const $ = cheerio.load(html);
+
+  // 텍스트가 없고
+  const text = $('body').text().replace(/\s+/g, '').trim();
+
+  // 의미 없는 태그만 있을 경우 (예: <p></p>, <br>)
+  const onlyEmptyElements = $('body')
+    .children()
+    .toArray()
+    .every((el) => {
+      const $el = $(el);
+      const tag = $el[0].tagName.toLowerCase();
+
+      const isEmptyParagraph = tag === 'p' && $el.text().trim() === '';
+      const isEmptyBr = tag === 'br';
+      return isEmptyParagraph || isEmptyBr;
+    });
+
+  return text === '' && onlyEmptyElements;
+};

--- a/src/components/common/TextEditor/viewer/viewerHtmlStyle.css
+++ b/src/components/common/TextEditor/viewer/viewerHtmlStyle.css
@@ -17,7 +17,7 @@
 
 .text-viewer p {
   color: var(--color-grayscale-500);
-  height: 24px;
+  min-height: 24px;
 }
 
 .text-viewer h1 {

--- a/src/components/page/wikicode/ProfileNoContent/ProfileNoContent.tsx
+++ b/src/components/page/wikicode/ProfileNoContent/ProfileNoContent.tsx
@@ -3,12 +3,18 @@ import { getHtmlStringIsEmpty } from '@/components/common/TextEditor/utils/handl
 import { useAuthContext } from '@/context/AuthContext';
 import clsx from 'clsx';
 import { useRouter } from 'next/navigation';
+import { Modal } from 'react-simplified-package';
+import QuestionModal from '../ProfileTitle/components/QuestionModal';
+import { useState } from 'react';
+import { GetProfileItemResponse } from '@/api/profile/getProfileAPI';
 
 interface Props {
+  wikiData: GetProfileItemResponse;
   content: string;
 }
 
-const ProfileNoContent = ({ content }: Props) => {
+const ProfileNoContent = ({ wikiData, content }: Props) => {
+  const [isQuizModalOpen, setIsQuizModalOpen] = useState(false);
   const { user } = useAuthContext();
   const router = useRouter();
 
@@ -30,9 +36,14 @@ const ProfileNoContent = ({ content }: Props) => {
             <br />
             위키에 참여해 친구의 정보를 작성해보세요!
           </p>
-          <Button variant='primary'>위키 참여하기</Button>
+          <Button variant='primary' onClick={() => setIsQuizModalOpen(true)}>
+            위키 참여하기
+          </Button>
         </div>
       )}
+      <Modal isOpen={isQuizModalOpen} onClose={() => setIsQuizModalOpen(false)}>
+        <QuestionModal wikiData={wikiData} onClose={() => setIsQuizModalOpen(false)} />
+      </Modal>
       {!isLogin && (
         <div className='flex flex-col items-center gap-[10px]'>
           <p className='text-center text-grayscale-400 text-lg-regular'>

--- a/src/components/page/wikicode/ProfileNoContent/ProfileNoContent.tsx
+++ b/src/components/page/wikicode/ProfileNoContent/ProfileNoContent.tsx
@@ -1,0 +1,52 @@
+import Button from '@/components/common/Button';
+import { getHtmlStringIsEmpty } from '@/components/common/TextEditor/utils/handlers/getHtmlStringIsEmpty';
+import { useAuthContext } from '@/context/AuthContext';
+import clsx from 'clsx';
+import { useRouter } from 'next/navigation';
+
+interface Props {
+  content: string;
+}
+
+const ProfileNoContent = ({ content }: Props) => {
+  const { user } = useAuthContext();
+  const router = useRouter();
+
+  const isEmpty = getHtmlStringIsEmpty(content);
+  const isLogin = user !== null;
+
+  const handleLoginClick = () => {
+    router.push('/login');
+  };
+
+  if (!isEmpty) return null;
+
+  return (
+    <div className={clsx('bg-gray-100 rounded-[15px] py-[40px]', 'flex flex-col items-center')}>
+      {isLogin && (
+        <div className='flex flex-col items-center gap-[10px]'>
+          <p className='text-center text-grayscale-400 text-lg-regular'>
+            아직 작성된 내용이 없네요.
+            <br />
+            위키에 참여해 친구의 정보를 작성해보세요!
+          </p>
+          <Button variant='primary'>위키 참여하기</Button>
+        </div>
+      )}
+      {!isLogin && (
+        <div className='flex flex-col items-center gap-[10px]'>
+          <p className='text-center text-grayscale-400 text-lg-regular'>
+            아직 작성된 내용이 없네요.
+            <br />
+            로그인 후 위키에 참여해보세요!
+          </p>
+          <Button variant='primary' onClick={handleLoginClick}>
+            로그인
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProfileNoContent;

--- a/src/components/page/wikicode/ProfileNoContent/ProfileNoContent.tsx
+++ b/src/components/page/wikicode/ProfileNoContent/ProfileNoContent.tsx
@@ -7,6 +7,7 @@ import { Modal } from 'react-simplified-package';
 import QuestionModal from '../ProfileTitle/components/QuestionModal';
 import { useState } from 'react';
 import { GetProfileItemResponse } from '@/api/profile/getProfileAPI';
+import { useWikiContext } from '@/context/WikiContext';
 
 interface Props {
   wikiData: GetProfileItemResponse;
@@ -16,6 +17,7 @@ interface Props {
 const ProfileNoContent = ({ wikiData, content }: Props) => {
   const [isQuizModalOpen, setIsQuizModalOpen] = useState(false);
   const { user } = useAuthContext();
+  const { isEditing } = useWikiContext();
   const router = useRouter();
 
   const isEmpty = getHtmlStringIsEmpty(content);
@@ -26,6 +28,7 @@ const ProfileNoContent = ({ wikiData, content }: Props) => {
   };
 
   if (!isEmpty) return null;
+  if (isEditing) return null;
 
   return (
     <div className={clsx('bg-gray-100 rounded-[15px] py-[40px]', 'flex flex-col items-center')}>

--- a/src/components/page/wikicode/ProfileTitle/ProfileTitle.tsx
+++ b/src/components/page/wikicode/ProfileTitle/ProfileTitle.tsx
@@ -10,6 +10,7 @@ import { useAuthContext } from '@/context/AuthContext';
 import { getProfilePingAPI } from '@/api/profile/getProfilePingAPI';
 import { toast } from 'cy-toast';
 import SnackBar from '@/components/common/Snackbar';
+import { getDisplayName } from '@/utils/displayName';
 
 interface Props {
   wikiData: GetProfileItemResponse;
@@ -62,7 +63,7 @@ const ProfileTitle = ({ wikiData, handleCancelClick, handleUpdateProfileSubmit }
           text-3xl-semibold
           md:text-5xl-semibold'
         >
-          {wikiData.name}
+          {getDisplayName(wikiData.name)}
         </h1>
         {isEditing && (
           <div className={clsx('flex flex-row gap-[10px]', 'sticky top-[120px]')}>

--- a/src/components/page/wikicode/WikiDetailSection.tsx
+++ b/src/components/page/wikicode/WikiDetailSection.tsx
@@ -19,6 +19,7 @@ import { ToastRender } from 'cy-toast';
 import { useUnloadAlert } from '@/hooks/useUnloadAlert';
 import ProfileQnAEditor from './ProfileQnAEditor/ProfileQnAEditor';
 import { uploadFileAPI } from '@/api/uploadFileAPI';
+import ProfileNoContent from './ProfileNoContent/ProfileNoContent';
 
 interface Props {
   wikiData: GetProfileItemResponse;
@@ -129,6 +130,7 @@ const WikiDetailSection = ({ wikiData }: Props) => {
           <ProfileCard className='lg:hidden' wikiData={wikiData} />
         </div>
         <ProfileContent editor={editor} setTempFiles={setTempFiles} wikiData={wikiData} />
+        <ProfileNoContent content={wikiData.content} />
         <Modal isOpen={isExpiredModalOpen} onClose={() => setIsExpiredtModalOpen(false)}>
           <ExpiredModal onClose={() => setIsExpiredtModalOpen(false)} />
         </Modal>

--- a/src/components/page/wikicode/WikiDetailSection.tsx
+++ b/src/components/page/wikicode/WikiDetailSection.tsx
@@ -130,7 +130,7 @@ const WikiDetailSection = ({ wikiData }: Props) => {
           <ProfileCard className='lg:hidden' wikiData={wikiData} />
         </div>
         <ProfileContent editor={editor} setTempFiles={setTempFiles} wikiData={wikiData} />
-        <ProfileNoContent content={wikiData.content} />
+        <ProfileNoContent wikiData={wikiData} content={wikiData.content} />
         <Modal isOpen={isExpiredModalOpen} onClose={() => setIsExpiredtModalOpen(false)}>
           <ExpiredModal onClose={() => setIsExpiredtModalOpen(false)} />
         </Modal>


### PR DESCRIPTION
# 📜 작업 내용

## 💡css 수정
`components/common/TextEditor/viewer/viewerHtmlStyle.css`

- 기존: html viewer에서 p태그의 내용이 없더라도 항상 높이를 차지하게 만들기 위해 `height: 16px` 적용(고정값)
- 변경: p태그의 내용이 여러줄 일 때 대응을 위해 `min-height: 16px` 로 변경

## 💡 결과물
아래와 같이 개선 되었습니다.
<img width="1064" height="550" alt="image" src="https://github.com/user-attachments/assets/60828a4e-08d1-491a-b206-bec9491e15c4" />
