### PR TITLE
fix(LinkModal): 메타데이터 수집 pupeteer => microlink 방식으로 변경

### DIFF
--- a/src/app/api/fetch-og/route.ts
+++ b/src/app/api/fetch-og/route.ts
@@ -1,37 +1,29 @@
 import { NextRequest } from 'next/server';
-import puppeteer from 'puppeteer';
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
-  const url = searchParams.get('url');
+  const targetUrl = searchParams.get('url');
 
-  if (!url) {
+  if (!targetUrl) {
     return new Response(JSON.stringify({ error: 'Missing URL' }), { status: 400 });
   }
 
   try {
-    const browser = await puppeteer.launch({ headless: true });
-    const page = await browser.newPage();
-    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
+    const res = await fetch(`https://api.microlink.io/?url=${encodeURIComponent(targetUrl)}`);
+    const { data } = await res.json();
 
-    const ogData = await page.evaluate(() => {
-      const get = (prop: string) =>
-        document.querySelector(`meta[property="${prop}"]`)?.getAttribute('content') || '';
-      return {
-        title: get('og:title'),
-        description: get('og:description'),
-        image: get('og:image'),
-      };
-    });
-
-    await browser.close();
+    const ogData = {
+      title: data.title || '',
+      description: data.description || '',
+      image: data.image?.url || '',
+    };
 
     return new Response(JSON.stringify(ogData), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (err) {
-    return new Response(JSON.stringify({ error: 'puppeteer failed', details: String(err) }), {
+    return new Response(JSON.stringify({ error: 'Microlink fetch failed', details: String(err) }), {
       status: 500,
     });
   }


### PR DESCRIPTION
# 📜 작업 내용

## 💡메타데이터 수집 Next api 수정
`api/fetch-og/route.ts`

OpenGraph 노드 생성을 위해 메타데이터 수집 시 puppeteer 방식에서 microLink api 사용 방식으로 수정하였습니다.

## 💡 배포환경에서 문제 발생한 원인
Puppeteer는 내부적으로 Headless Chrome(Chromium)을 실행하여 웹페이지를 렌더링하고, 메타데이터를 수집합니다.
로컬 환경에서는 puppeteer가 자동으로 Chromium을 설치하고 실행할 수 있어 정상 작동하지만,
Vercel 배포 환경은 서버리스 구조로 인해 실행 파일 설치나 실행에 제한이 있어 Chromium 실행 자체가 불가능하거나 실패합니다.
이로 인해 puppeteer 기반의 메타데이터 수집은 Vercel에서 동작하지 않습니다.

MicroLink api를 사용하면 클라이언트에서 메타데이터가 생성되는 사이트도 문제없이 대응이 가능하며
vercel 배포환경에서도 문제없이 작동합니다.
![Animation](https://github.com/user-attachments/assets/0963e7b7-0865-4f94-b390-9affde456d7b)
