### PR TITLE
refactor: 위키상세페이지 변경사항 4건(css) 반영

### DIFF
--- a/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
@@ -68,6 +68,8 @@ const ProfileInput = ({ id, className, value, onChange }: InputProps) => {
       className={clsx(
         'bg-grayscale-100 rounded-[10px] text-xs-regular px-[16px] py-[10px] w-full',
         'grow',
+        'outline-none border-1 border-transparent',
+        'focus:border-primary-green-200',
         className,
       )}
       value={value}

--- a/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
@@ -20,9 +20,9 @@ const ProfileLabel = ({ children, className }: LabelProps) => {
     <label
       className={clsx(
         'text-grayscale-400',
-        'text-xs-regular w-[55px]',
-        'md:text-md-regular md:w-[55px]',
-        'xl:text-md-regular xl:w-[60px]',
+        'text-xs-regular w-[60px]',
+        'md:text-md-regular md:w-[65px]',
+        'xl:text-md-regular xl:w-[70px]',
         'shrink-0',
         className,
       )}

--- a/src/components/page/wikicode/ProfileCard/components/ProfileImageEditor.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileImageEditor.tsx
@@ -79,11 +79,7 @@ const ProfileImageEditor = ({ imageUrl }: Props) => {
     wikiProfile.image === null ? '/images/default_profile.svg' : wikiProfile.image;
 
   return (
-    <div className='flex flex-col items-center gap-[10px]'>
-      <Button variant='secondary' className='px-2 py-1' onClick={handleImageDefault}>
-        기본 이미지
-      </Button>
-
+    <div className='mb-[30px]'>
       <div className='relative aspect-square w-full'>
         <div className={clsx('relative rounded-full overflow-hidden', 'w-full h-full')}>
           <Image className='object-cover' src={nextImageSrc} alt='프로필 이미지' layout='fill' />
@@ -110,6 +106,13 @@ const ProfileImageEditor = ({ imageUrl }: Props) => {
           </div>
         )}
       </div>
+      <Button
+        variant='secondary'
+        className='text-xs absolute right-[20px] bottom-0 px-2 py-1 bg-white hover:bg-primary-green-100'
+        onClick={handleImageDefault}
+      >
+        기본 이미지 적용
+      </Button>
     </div>
   );
 };

--- a/src/components/page/wikicode/ProfileCard/components/ProfileItemListViewer.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileItemListViewer.tsx
@@ -44,7 +44,6 @@ const ProfileItemListViewer = ({ wikiData }: Props) => {
                 'bg-gray-100 rounded-[10px] text-center py-[10px]',
                 'text-grayscale-400',
                 'flex flex-col items-center justify-center',
-                'max-w-[200px]',
               )}
             >
               <span className='whitespace-nowrap'>작성된 내용이</span>


### PR DESCRIPTION
# 📜 작업내용

## 💡 금일 미팅 때 요청주신 변경사항을 반영 반영하였습니다.

- 위키 상세페이지 프로필 카드의 label과 input의 간격 확대
- 위키 상세페이지 프로필 카드 수정 시 `기본이미지 적용` 버튼 위치 수정
- 위키 상세페이지 프로필 카드 수정 시 input border primary color 적용

<img width="271" height="426" alt="image" src="https://github.com/user-attachments/assets/e8f70c6a-d312-4ad7-9051-20e3740b7f63" />


- 위키 상세페이지 프로필 카드 `작성된 내용이 없어요` 구역 최대 너비만큼 차지하도록 수정
<img width="692" height="410" alt="image" src="https://github.com/user-attachments/assets/915adc54-92c7-456d-83c9-74f653cb8d31" />
