### PR TITLE
refactor: 로그인페이지에서의 router처리방법 변경

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -84,9 +84,7 @@ export default function SignupPage() {
         { duration: 2000, closeDuration: 200, openDuration: 200 },
       );
 
-      setTimeout(() => {
-        router.push('/login');
-      }, 2000);
+      router.push('/login?from=signup');
     } catch (error) {
       const axiosError = error as AxiosError;
       const errorMessage =

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -10,7 +10,7 @@ interface AuthContextType {
   isAuthenticated: boolean; // 로그인 여부
   user: UserData | null; // 로그인한 사용자 정보
   accessToken: string | null; // API 요청에 사용할 접근 토큰
-  login: (accessToken: string, refreshToken: string, user: UserData) => void; //로그인 처리 함수
+  login: (accessToken: string, refreshToken: string, user: UserData, fromSignup?: boolean) => void; //로그인 처리 함수
   logout: () => void; //로그아웃 처리 함수
 }
 
@@ -26,7 +26,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   // 로그인 함수 정의: 외부에서 로그인 API 호출 성공 시 이 함수를 호출
   const login = useCallback(
-    (newAccessToken: string, newRefreshToken: string, newUser: UserData) => {
+    (newAccessToken: string, newRefreshToken: string, newUser: UserData, fromSignup?: boolean) => {
       // Access Token (유효 기간: 5분)
       CookiesJs.set('accessToken', newAccessToken, {
         expires: 5 / (24 * 60),
@@ -47,8 +47,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setUser(newUser);
       setIsAuthenticated(true);
 
-      // 로그인 성공 후 메인 페이지('/')로 이동시킵니다.
-      router.push('/');
+      if (fromSignup) {
+        router.push('/mypage');
+      } else {
+        router.back();
+      }
     },
     [router],
   );


### PR DESCRIPTION
## 구현 사항
- 회원가입 후 로그인를 했을 때엔 `mypaage`로 이동하고 그 외의 경우에는 이전 페이지로 이동하도로 구현
  - 명시적 쿼리 파라미터 전달 방식 사용(`router.push('/path?key=value')`
  - URL의 물음표 뒤에 `key-value` 형태로 데이터를 초함해 페이지를 이동 방식 사용