### PR TITLE
feat: 로딩화면 제작, 위키상세페이지 error 라우팅 처리

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import AuthHeaderRenderer from '@/components/layout/AuthHeaderRenderer';
 import { Suspense } from 'react';
 import Animation from '@/components/common/Animation';
 import { ToastRender } from 'cy-toast';
+import LoadingOverlay from '@/components/common/LoadingOverlay';
 
 const vercelUrl = process.env.VERCEL_URL;
 const nextOrigin = `https://${vercelUrl}`;
@@ -64,7 +65,7 @@ export default function RootLayout({
         antialiased`}
       >
         <ToastRender />
-        <Suspense>
+        <Suspense fallback={<LoadingOverlay>페이지를 불러오고 있어요</LoadingOverlay>}>
           <AuthProvider>
             <Animation>
               <AuthHeaderRenderer />

--- a/src/app/testloadingoverlay/page.tsx
+++ b/src/app/testloadingoverlay/page.tsx
@@ -1,0 +1,7 @@
+import LoadingOverlay from '@/components/common/LoadingOverlay';
+
+const TestLoading = () => {
+  return <LoadingOverlay>페이지를 불러오고 있어요</LoadingOverlay>;
+};
+
+export default TestLoading;

--- a/src/app/wiki/[code]/loading.tsx
+++ b/src/app/wiki/[code]/loading.tsx
@@ -1,0 +1,12 @@
+import LoadingOverlay from '@/components/common/LoadingOverlay';
+
+const Loading = () => {
+  console.log('로딩중');
+  return (
+    <div>
+      로딩중<LoadingOverlay>페이지를 불러오고 있어요</LoadingOverlay>
+    </div>
+  );
+};
+
+export default Loading;

--- a/src/components/common/LoadingOverlay.tsx
+++ b/src/components/common/LoadingOverlay.tsx
@@ -1,0 +1,23 @@
+import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const LoadingOverlay = ({ children }: Props) => {
+  return (
+    <div className='fixed inset-0 flex flex-col justify-center items-center gap-[20px] z-40 bg-white'>
+      <p className='text-2xl-medium text-primary-green-300'>{children}</p>
+      <LoadingSpinner.dotBounce
+        themeColor='var(--color-primary-green-300)'
+        dotCount={6}
+        dotSize={10}
+        dotGap={5}
+        bounceHeight={5}
+        bounceSpeed={0.1}
+      />
+    </div>
+  );
+};
+
+export default LoadingOverlay;

--- a/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
@@ -68,6 +68,8 @@ const ProfileInput = ({ id, className, value, onChange }: InputProps) => {
       className={clsx(
         'bg-grayscale-100 rounded-[10px] text-xs-regular px-[16px] py-[10px] w-full',
         'grow',
+        'outline-none border-1 border-transparent',
+        'focus:border-primary-green-200',
         className,
       )}
       value={value}

--- a/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
@@ -20,9 +20,9 @@ const ProfileLabel = ({ children, className }: LabelProps) => {
     <label
       className={clsx(
         'text-grayscale-400',
-        'text-xs-regular w-[55px]',
-        'md:text-md-regular md:w-[55px]',
-        'xl:text-md-regular xl:w-[60px]',
+        'text-xs-regular w-[60px]',
+        'md:text-md-regular md:w-[65px]',
+        'xl:text-md-regular xl:w-[70px]',
         'shrink-0',
         className,
       )}

--- a/src/components/page/wikicode/ProfileCard/components/ProfileImageEditor.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileImageEditor.tsx
@@ -79,11 +79,7 @@ const ProfileImageEditor = ({ imageUrl }: Props) => {
     wikiProfile.image === null ? '/images/default_profile.svg' : wikiProfile.image;
 
   return (
-    <div className='flex flex-col items-center gap-[10px]'>
-      <Button variant='secondary' className='px-2 py-1' onClick={handleImageDefault}>
-        기본 이미지
-      </Button>
-
+    <div className='mb-[30px]'>
       <div className='relative aspect-square w-full'>
         <div className={clsx('relative rounded-full overflow-hidden', 'w-full h-full')}>
           <Image className='object-cover' src={nextImageSrc} alt='프로필 이미지' layout='fill' />
@@ -110,6 +106,13 @@ const ProfileImageEditor = ({ imageUrl }: Props) => {
           </div>
         )}
       </div>
+      <Button
+        variant='secondary'
+        className='text-xs absolute right-[20px] bottom-0 px-2 py-1 bg-white hover:bg-primary-green-100'
+        onClick={handleImageDefault}
+      >
+        기본 이미지 적용
+      </Button>
     </div>
   );
 };

--- a/src/components/page/wikicode/ProfileCard/components/ProfileItemListViewer.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileItemListViewer.tsx
@@ -44,7 +44,6 @@ const ProfileItemListViewer = ({ wikiData }: Props) => {
                 'bg-gray-100 rounded-[10px] text-center py-[10px]',
                 'text-grayscale-400',
                 'flex flex-col items-center justify-center',
-                'max-w-[200px]',
               )}
             >
               <span className='whitespace-nowrap'>작성된 내용이</span>


### PR DESCRIPTION
#  📜 작업내용

## 💡 공통 로딩 화면 제작(LoadingOverlay.tsx)
LoadingOverlay.tsx는 공용컴포넌트입니다.
children으로 text를 전달하여 화면에 표시할 수 있습니다.
```tsx
import LoadingSpinner from './LoadingSpinner/LoadingSpinner';

interface Props {
  children: React.ReactNode;
}

const LoadingOverlay = ({ children }: Props) => {
  return (
    <div className='fixed inset-0 flex flex-col justify-center items-center gap-[20px] z-40 bg-white'>
      <p className='text-2xl-medium text-primary-green-300'>{children}</p>
      <LoadingSpinner.dotBounce
        themeColor='var(--color-primary-green-300)'
        dotCount={6}
        dotSize={10}
        dotGap={5}
        bounceHeight={5}
        bounceSpeed={0.1}
      />
    </div>
  );
};

export default LoadingOverlay;
```

## 💡 예시 
`/testloadingover`

```tsx
import LoadingOverlay from '@/components/common/LoadingOverlay';

const TestLoading = () => {
  return <LoadingOverlay>게시글을 업로드하고 있어요.</LoadingOverlay>;
};

export default TestLoading;

```
![Animation](https://github.com/user-attachments/assets/5a057e15-4f3f-485e-8684-8329caec455b)


## 💡 `app/layout.tsx`
root layout suspense fallback 에 로딩화면 컴포넌트를 적용하였습니다.

```tsx
        <Suspense fallback={<LoadingOverlay>페이지를 불러오고 있어요</LoadingOverlay>}>
```

## 💡 `app/wiki/[code]/loading.tsx`
위키 상세 페이지 진입 시 로딩 화면을 적용하였습니다.
<img width="1661" height="939" alt="image" src="https://github.com/user-attachments/assets/c0918fd9-8732-449b-bab6-8dceb429893f" />

## 💡 게시글 제출 로딩 화면
위키 상세 페이지에서 편집 후 수정 완료 시 로딩 화면이 나오도록 수정하였습니다. (↑ 예시 참조)

## 💡 api error 라우팅
api 호출 실패 시 `/error`로 라우팅 처리하였습니다.

## 💡 결과물
![Animation](https://github.com/user-attachments/assets/5bdb0174-d290-4805-a117-efe94a24d879)
