### PR TITLE
feat: 위키 상세페이지 TextEditor 최소 높이 지정, 외부 클릭시 커서 focus 이동 기능 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import AuthHeaderRenderer from '@/components/layout/AuthHeaderRenderer';
 import { Suspense } from 'react';
 import Animation from '@/components/common/Animation';
 import { ToastRender } from 'cy-toast';
+import LoadingOverlay from '@/components/common/LoadingOverlay';
 
 const vercelUrl = process.env.VERCEL_URL;
 const nextOrigin = `https://${vercelUrl}`;
@@ -64,7 +65,7 @@ export default function RootLayout({
         antialiased`}
       >
         <ToastRender />
-        <Suspense>
+        <Suspense fallback={<LoadingOverlay>페이지를 불러오고 있어요</LoadingOverlay>}>
           <AuthProvider>
             <Animation>
               <AuthHeaderRenderer />

--- a/src/app/testloadingoverlay/page.tsx
+++ b/src/app/testloadingoverlay/page.tsx
@@ -1,0 +1,7 @@
+import LoadingOverlay from '@/components/common/LoadingOverlay';
+
+const TestLoading = () => {
+  return <LoadingOverlay>페이지를 불러오고 있어요</LoadingOverlay>;
+};
+
+export default TestLoading;

--- a/src/app/wiki/[code]/loading.tsx
+++ b/src/app/wiki/[code]/loading.tsx
@@ -1,0 +1,12 @@
+import LoadingOverlay from '@/components/common/LoadingOverlay';
+
+const Loading = () => {
+  console.log('로딩중');
+  return (
+    <div>
+      로딩중<LoadingOverlay>페이지를 불러오고 있어요</LoadingOverlay>
+    </div>
+  );
+};
+
+export default Loading;

--- a/src/components/common/LoadingOverlay.tsx
+++ b/src/components/common/LoadingOverlay.tsx
@@ -1,0 +1,23 @@
+import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const LoadingOverlay = ({ children }: Props) => {
+  return (
+    <div className='fixed inset-0 flex flex-col justify-center items-center gap-[20px] z-40 bg-white'>
+      <p className='text-2xl-medium text-primary-green-300'>{children}</p>
+      <LoadingSpinner.dotBounce
+        themeColor='var(--color-primary-green-300)'
+        dotCount={6}
+        dotSize={10}
+        dotGap={5}
+        bounceHeight={5}
+        bounceSpeed={0.1}
+      />
+    </div>
+  );
+};
+
+export default LoadingOverlay;

--- a/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
@@ -68,6 +68,8 @@ const ProfileInput = ({ id, className, value, onChange }: InputProps) => {
       className={clsx(
         'bg-grayscale-100 rounded-[10px] text-xs-regular px-[16px] py-[10px] w-full',
         'grow',
+        'outline-none border-1 border-transparent',
+        'focus:border-primary-green-200',
         className,
       )}
       value={value}

--- a/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
@@ -20,9 +20,9 @@ const ProfileLabel = ({ children, className }: LabelProps) => {
     <label
       className={clsx(
         'text-grayscale-400',
-        'text-xs-regular w-[55px]',
-        'md:text-md-regular md:w-[55px]',
-        'xl:text-md-regular xl:w-[60px]',
+        'text-xs-regular w-[60px]',
+        'md:text-md-regular md:w-[65px]',
+        'xl:text-md-regular xl:w-[70px]',
         'shrink-0',
         className,
       )}

--- a/src/components/page/wikicode/ProfileCard/components/ProfileImageEditor.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileImageEditor.tsx
@@ -79,11 +79,7 @@ const ProfileImageEditor = ({ imageUrl }: Props) => {
     wikiProfile.image === null ? '/images/default_profile.svg' : wikiProfile.image;
 
   return (
-    <div className='flex flex-col items-center gap-[10px]'>
-      <Button variant='secondary' className='px-2 py-1' onClick={handleImageDefault}>
-        기본 이미지
-      </Button>
-
+    <div className='mb-[30px]'>
       <div className='relative aspect-square w-full'>
         <div className={clsx('relative rounded-full overflow-hidden', 'w-full h-full')}>
           <Image className='object-cover' src={nextImageSrc} alt='프로필 이미지' layout='fill' />
@@ -110,6 +106,13 @@ const ProfileImageEditor = ({ imageUrl }: Props) => {
           </div>
         )}
       </div>
+      <Button
+        variant='secondary'
+        className='text-xs absolute right-[20px] bottom-0 px-2 py-1 bg-white hover:bg-primary-green-100'
+        onClick={handleImageDefault}
+      >
+        기본 이미지 적용
+      </Button>
     </div>
   );
 };

--- a/src/components/page/wikicode/ProfileCard/components/ProfileItemListViewer.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileItemListViewer.tsx
@@ -44,7 +44,6 @@ const ProfileItemListViewer = ({ wikiData }: Props) => {
                 'bg-gray-100 rounded-[10px] text-center py-[10px]',
                 'text-grayscale-400',
                 'flex flex-col items-center justify-center',
-                'max-w-[200px]',
               )}
             >
               <span className='whitespace-nowrap'>작성된 내용이</span>

--- a/src/components/page/wikicode/ProfileContent.tsx/ProfileContent.tsx
+++ b/src/components/page/wikicode/ProfileContent.tsx/ProfileContent.tsx
@@ -5,6 +5,7 @@ import ContentViewer from '@/components/common/TextEditor/ContentViewer';
 import ToolBar from '@/components/common/TextEditor/ToolBar';
 import { useAuthContext } from '@/context/AuthContext';
 import { useWikiContext } from '@/context/WikiContext';
+import EditorClickCatcher from '@/components/common/TextEditor/textarea/EditorClickCatcher';
 interface Props {
   editor: Editor;
   setTempFiles: React.Dispatch<React.SetStateAction<Record<string, File>>>;
@@ -28,7 +29,10 @@ const ProfileContent = ({ editor, setTempFiles, wikiData }: Props) => {
           <div className='sticky top-[110px] md:top-[130px]  z-1'>
             <ToolBar editor={editor} setTempFiles={setTempFiles} />
           </div>
-          <ContentEditor editor={editor} />
+          <div className='mt-[10px] flex flex-col min-h-[237px]'>
+            <ContentEditor editor={editor} />
+            <EditorClickCatcher editor={editor} />
+          </div>
         </div>
       )}
       {!editCondition && <ContentViewer content={wikiData.content} />}


### PR DESCRIPTION
# 📜 작업 내용

## 💡 위키 상세 페이지
위키 상세 페이지에서 Text Editor가 최소 높이를 유지하도록 설정
Text Area 외부를 클릭해도 자동으로 Text Area로 Focus 이동하도록 수정

## 💡 min height 적용방법
@3rdflr 
아래와 같이 `ContentEditor`와 `EditorClickCatcher`를 감싸는 부모 div에 `flex flex-col`을 지정해주시고, min height를 설정해주시면 됩니다.
```tsx
  <div className='mt-[10px] flex flex-col min-h-[237px]'>
    <ContentEditor editor={editor} />
    <EditorClickCatcher editor={editor} />
  </div>
```

## 💡 결과물
![Animation](https://github.com/user-attachments/assets/f5915f4b-3cf6-476b-8698-a89f84890483)
