### PR TITLE
fix: 프로필 카드 overflow hidden 처리, sns 클릭 시 페이지 이동 기능 추가

### DIFF
--- a/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileField.tsx
@@ -32,6 +32,30 @@ const ProfileLabel = ({ children, className }: LabelProps) => {
   );
 };
 
+interface LinkProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const ProfileLabelLink = ({ children, className }: LinkProps) => {
+  return (
+    <a
+      href={String(children)}
+      target='_blank'
+      className={clsx(
+        'text-grayscale-500 hover:text-primary-green-300 whitespace-nowrap',
+        'text-xs-regular',
+        'md:text-md-regular',
+        'xl:text-md-regular',
+        'grow',
+        className,
+      )}
+    >
+      {children}
+    </a>
+  );
+};
+
 interface ValueProps {
   children: React.ReactNode;
   className?: string;
@@ -79,6 +103,7 @@ const ProfileInput = ({ id, className, value, onChange }: InputProps) => {
 };
 
 ProfileField.label = ProfileLabel;
+ProfileField.link = ProfileLabelLink;
 ProfileField.value = ProfileValue;
 ProfileField.input = ProfileInput;
 

--- a/src/components/page/wikicode/ProfileCard/components/ProfileItemListViewer.tsx
+++ b/src/components/page/wikicode/ProfileCard/components/ProfileItemListViewer.tsx
@@ -21,12 +21,13 @@ const ProfileItemListViewer = ({ wikiData }: Props) => {
   const emptyMap = fieldMap.filter(([_, value]) => value === '');
 
   return (
-    <div className='flex flex-col gap-[10px]'>
+    <div className='flex flex-col gap-[10px] overflow-hidden'>
       {filledMap.length > 0 &&
         filledMap.map(([label, value]) => (
           <ProfileField key={label}>
             <ProfileField.label>{label}</ProfileField.label>
-            <ProfileField.value>{value}</ProfileField.value>
+            {label !== 'SNS' && <ProfileField.value>{value}</ProfileField.value>}
+            {label === 'SNS' && <ProfileField.link>{value}</ProfileField.link>}
           </ProfileField>
         ))}
       {emptyMap.length > 0 && (


### PR DESCRIPTION
# 📜 작업내용

위키상세 페이지 프로필 카드 내용 overflow hidden 처리
sns 클릭시 페이지 이동 기능 추가

![Animation](https://github.com/user-attachments/assets/339767c7-5082-4cef-a45d-d660b7a56c1d)
