### PR TITLE
fix: 프로필이 적용이 안되는 버그, 에티터 수정시 입력 이전 Length가 표기 되지않는 버그 수정

### DIFF
--- a/src/components/common/HeaderAfterLogin.tsx
+++ b/src/components/common/HeaderAfterLogin.tsx
@@ -46,7 +46,7 @@ const HeaderAfterLogin = () => {
     };
 
     fetchProfileImage();
-  }, [user]);
+  }, [user?.profile?.code]);
 
   // 폴링 및 알림 상태 관리
   useEffect(() => {

--- a/src/components/common/TextEditor/utils/hooks/useTextEditor.tsx
+++ b/src/components/common/TextEditor/utils/hooks/useTextEditor.tsx
@@ -7,7 +7,7 @@ import { LocalVideoExtension } from '@/components/common/TextEditor/utils/extens
 import { YoutubeExtension } from '@/components/common/TextEditor/utils/extensions/YoutubeExtension';
 import { OGLinkExtension } from '../extensions/OGLinkExtension';
 import { LocalImageExtension } from '../extensions/LocalImageExtension';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { getHtmlLength } from '../handlers/getHtmlLength';
 import { removeHeadingIds } from '../handlers/removeHeadingIds';
 
@@ -109,6 +109,14 @@ export const useTextEditor = ({ initialContent = '' }: Props = {}) => {
     // Don't render immediately on the server to avoid SSR issues
     immediatelyRender: false,
   });
+
+  useEffect(() => {
+    if (editor) {
+      setLengthWithSpaces(getHtmlLength.withSpaces(editor));
+      setLengthWithoutSpaces(getHtmlLength.withoutSpaces(editor));
+    }
+  }, [editor]);
+
   return {
     editor,
     tempFiles,


### PR DESCRIPTION
# 프로필이 적용이 안되는 버그

<img width="437" height="397" alt="스크린샷 2025-08-02 오전 9 03 00" src="https://github.com/user-attachments/assets/17ef3590-b402-4f72-aa62-4909c8b50916" />

프로필이 적용 되었음에도 읽어오지 못하는것 같아서 

<img width="727" height="439" alt="스크린샷 2025-08-02 오전 8 53 30" src="https://github.com/user-attachments/assets/9623a4a5-4fae-46f0-8245-c1ecc26335a6" />

기존 useEffect 의 의존성 배열에 user가 참조형 객체여서 인식을 못하는것 같아

user.profile.code 자체를 의존성 배열에 넣어주는걸로 코드를 변경했습니다

<img width="415" height="312" alt="스크린샷 2025-08-02 오전 9 14 12" src="https://github.com/user-attachments/assets/a2b49233-0f95-4063-bf16-d20a8ef8022d" />


# 에티터 수정버튼으로 값을 전해주는 경우 Length가 표기되지않는 버그

<img width="1092" height="784" alt="스크린샷 2025-08-02 오전 9 03 16" src="https://github.com/user-attachments/assets/7f0a4c4f-2396-4fbe-97de-14d9ad5ad7b1" />

기존 onUpdate 함수를 통해 length를 구해와서

input에 입력이 들어가기 이전 단계에서는 length가 0 으로 기존 입력값을 불러오지 못하는 버그가 있었습니다

<img width="577" height="140" alt="스크린샷 2025-08-02 오전 8 54 02" src="https://github.com/user-attachments/assets/8767c436-1663-4e4a-a70b-58f8c00d1ca4" />

useEffect를 사용해서 editor가 생성될 떄 마다 length 값을 계산해주는걸로 변경했습니다
