### PR TITLE
fix: 위키 생성페이지 이동 이슈 해결

### DIFF
--- a/src/app/boards/page.tsx
+++ b/src/app/boards/page.tsx
@@ -1,7 +1,6 @@
 import BoardsBest from '@/components/page/boards/BoardsBest';
 import BoardsHeader from '@/components/page/boards/BoardsHeader';
 import BoardsLists from '@/components/page/boards/BoardsLists';
-import LoadingOverlay from '@/components/common/LoadingOverlay';
 import { Suspense } from 'react';
 
 export default function Boards() {
@@ -14,8 +13,9 @@ export default function Boards() {
       <BoardsHeader />
       <Suspense
         fallback={
-          <div>
-            <LoadingOverlay>페이지를 불러오고 있어요</LoadingOverlay>
+          <div className='text-center p-8'>
+            <div>게시글을 불러오는 중...</div>
+            <div className='animate-pulse'>⏳</div>
           </div>
         }
       >

--- a/src/app/hooks/useMediaQuery.tsx
+++ b/src/app/hooks/useMediaQuery.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+const useMediaQuery = (query: string): boolean => {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    setMatches(mediaQuery.matches);
+
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mediaQuery.addEventListener('change', handler);
+
+    return () => mediaQuery.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+};
+
+export default useMediaQuery;

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -62,6 +62,14 @@ const SettingPage = () => {
         <hr className='my-5 border-t border-grayscale-300 w-auto' />
         <div className='flex flex-col gap-5'>
           <a
+            href='/mypage'
+            className='text-lg font-semibold 
+            flex items-center justify-between'
+          >
+            위키 생성하기
+            <IconArrowRight className='size-6 fill-grayscale-400' />
+          </a>
+          <a
             href='/passwordChangePage'
             className='text-lg font-semibold 
             flex items-center justify-between'

--- a/src/app/testeditor/page.tsx
+++ b/src/app/testeditor/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useTextEditor } from '@/components/common/TextEditor/utils/hooks/useTextEditor';
+import ToolBar from '../../components/common/TextEditor/ToolBar';
+import { handlehtmlParse } from '@/components/common/TextEditor/utils/handlers/handleHtmlParse';
+import { useState } from 'react';
+import ContentViewer from '@/components/common/TextEditor/ContentViewer';
+import ContentEditor from '@/components/common/TextEditor/ContentEditor';
+import { getHtmlFirstImageSrc } from '@/components/common/TextEditor/utils/handlers/getHtmlFirstImageSrc';
+
+const TestEditor = () => {
+  const { editor, tempFiles, setTempFiles, lengthWithSpaces, lengthWithoutSpaces } =
+    useTextEditor();
+  const [content, setContent] = useState('');
+
+  const handleRenderClick = async () => {
+    if (!editor) return;
+    const nextContent = await handlehtmlParse({ editor, files: tempFiles });
+    setContent(nextContent);
+  };
+
+  const handleGetImageSrcClick = () => {
+    if (!editor) return;
+    if (!content) {
+      alert('HTML파싱을 먼저 진행해주세요.');
+    }
+    const nextImageSrc = getHtmlFirstImageSrc(content);
+    console.log(nextImageSrc);
+  };
+
+  if (!editor) return;
+  return (
+    <div className='p-3 max-w-[960px] mx-auto flex flex-col gap-[20px]'>
+      <div>
+        <p>
+          <span>공백 포함: </span>
+          {lengthWithSpaces}
+        </p>
+      </div>
+      <div>
+        <p>
+          <span>공백 제외: </span>
+          {lengthWithoutSpaces}
+        </p>
+      </div>
+      <ToolBar editor={editor} setTempFiles={setTempFiles} />
+      <ContentEditor editor={editor} />
+      <button onClick={handleRenderClick}>파싱 시작</button>
+      <button onClick={handleGetImageSrcClick}>첫번째 이미지 경로 추출</button>
+      <ContentViewer content={content} />
+    </div>
+  );
+};
+
+export default TestEditor;

--- a/src/app/testloadingoverlay/page.tsx
+++ b/src/app/testloadingoverlay/page.tsx
@@ -1,0 +1,7 @@
+import LoadingOverlay from '@/components/common/LoadingOverlay';
+
+const TestLoading = () => {
+  return <LoadingOverlay>페이지를 불러오고 있어요</LoadingOverlay>;
+};
+
+export default TestLoading;

--- a/src/app/testmodals/page.tsx
+++ b/src/app/testmodals/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState } from 'react';
+import { Modal } from 'react-simplified-package';
+
+export default function DashboardPage() {
+  const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+
+  return (
+    <div>
+      <button onClick={() => setIsProfileModalOpen(true)}>Edit Profile</button>
+      <br />
+      <br />
+      <br />
+      <br />
+      <button onClick={() => setIsSettingsModalOpen(true)}>App Settings</button>
+
+      {/* Profile Modal */}
+      <Modal isOpen={isProfileModalOpen} onClose={() => setIsProfileModalOpen(false)}>
+        <h4>User Profile</h4>
+        <p>Manage your personal details here.</p>
+      </Modal>
+
+      {/* Settings Modal */}
+      <Modal isOpen={isSettingsModalOpen} onClose={() => setIsSettingsModalOpen(false)}>
+        <h4>Application Settings</h4>
+        <p>Configure your application preferences.</p>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/testspinner/page.tsx
+++ b/src/app/testspinner/page.tsx
@@ -1,0 +1,50 @@
+import LoadingSpinner from '@/components/common/LoadingSpinner/LoadingSpinner';
+
+const TestSpinner = () => {
+  return (
+    <div className='p-10 flex flex-col gap-5 items-center'>
+      <LoadingSpinner.dotBounce
+        themeColor='var(--color-primary-green-300)'
+        dotCount={5}
+        dotSize={15}
+        dotGap={10}
+        bounceHeight={5}
+        bounceSpeed={0.15}
+      />
+      <LoadingSpinner.dotBounce
+        themeColor='var(--color-primary-green-300)'
+        dotCount={12}
+        dotSize={10}
+        dotGap={5}
+        bounceHeight={5}
+        bounceSpeed={0.1}
+      />
+      <LoadingSpinner.dotCircle
+        themeColor='var(--color-primary-green-300)'
+        dotCount={8}
+        dotSize={12}
+        distanceFromCenter={30}
+      />
+      <LoadingSpinner.dotCircle
+        themeColor='var(--color-primary-green-300)'
+        dotCount={20}
+        dotSize={3}
+        distanceFromCenter={15}
+      />
+      <LoadingSpinner.lineCircle
+        themeColor='var(--color-primary-green-300)'
+        lineWeight={8}
+        distanceFromCenter={30}
+        spinSpeed={2}
+      />
+      <LoadingSpinner.lineCircle
+        themeColor='var(--color-primary-green-300)'
+        lineWeight={3}
+        distanceFromCenter={6}
+        spinSpeed={1}
+      />
+    </div>
+  );
+};
+
+export default TestSpinner;

--- a/src/app/testtoast/ToastSection.tsx
+++ b/src/app/testtoast/ToastSection.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { toast } from 'cy-toast';
+import SnackBar from '../../components/common/Snackbar';
+
+const ModalSection = () => {
+  const handleSuccessClick = () => {
+    toast.run(
+      ({ isClosing, isOpening, index }) => (
+        <SnackBar variant='success' isOpening={isOpening} isClosing={isClosing} index={index}>
+          내 위키 링크가 복사되었습니다.
+        </SnackBar>
+      ),
+      {
+        duration: 3000, // 생략 가능
+        closeDuration: 200, // 생략 가능
+        openDuration: 200, // 생략 가능
+      },
+    );
+  };
+
+  const handleErrorClick = () => {
+    toast.run(({ isClosing, isOpening, index }) => (
+      <SnackBar variant='error' isOpening={isOpening} isClosing={isClosing} index={index}>
+        다른 친구가 편집하고 있어요. 나중에 다시 시도해 주세요.
+      </SnackBar>
+    ));
+  };
+
+  return (
+    <>
+      <div>
+        <button
+          className='text-xl-semibold p-1 border-1 cursor-pointer'
+          onClick={handleSuccessClick}
+        >
+          토스트 - 성공
+        </button>
+        <button className='text-xl-semibold p-1 border-1 cursor-pointer' onClick={handleErrorClick}>
+          토스트 - 실패
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default ModalSection;

--- a/src/app/testtoast/page.tsx
+++ b/src/app/testtoast/page.tsx
@@ -1,0 +1,14 @@
+import { ToastRender } from 'cy-toast';
+
+import ModalSection from './ToastSection';
+
+const TestPage = () => {
+  return (
+    <>
+      <ToastRender /> {/*Toast를 사용할 컴포넌트에 ToastRender 렌더링*/}
+      <ModalSection />
+    </>
+  );
+};
+
+export default TestPage;

--- a/src/app/testupload/page.tsx
+++ b/src/app/testupload/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { uploadFileAPI, UploadType } from '@/api/uploadFileAPI';
+import { useState } from 'react';
+
+const TestUpload = () => {
+  const [fileObject, setFileObject] = useState<File | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [uploadUrl, setUploadUrl] = useState('');
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setFileObject(file);
+  };
+
+  const handleImageUploadClick = async (type: UploadType) => {
+    if (!fileObject) return;
+    setError(null);
+    setLoading(true);
+    try {
+      const url = await uploadFileAPI({ fileObject: fileObject, type });
+      setUploadUrl(url);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className='bg-gray-100 flex flex-col gap-[10px] border-1 p-4 m-2 items-center'>
+        <label>
+          이미지 선택
+          <input type='file' onChange={handleInputChange} />
+        </label>
+        <button
+          className='border-1 bg-amber-200 p-1'
+          onClick={() => handleImageUploadClick('image')}
+        >
+          이미지 업로드
+        </button>
+      </div>
+      <div className='bg-gray-100 flex flex-col gap-[10px] border-1 p-4 m-2 items-center'>
+        <label>
+          비디오 선택
+          <input type='file' onChange={handleInputChange} />
+        </label>
+        <button
+          className='border-1 bg-amber-200 p-1'
+          onClick={() => handleImageUploadClick('video')}
+        >
+          비디오 업로드
+        </button>
+      </div>
+      {loading && <div>로딩중...</div>}
+      {error && (
+        <div>
+          오류: <p>{error.message}</p>
+        </div>
+      )}
+      {uploadUrl && (
+        <div className='flex flex-col items-center'>
+          업로드 성공!: <p>{uploadUrl}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TestUpload;

--- a/src/app/wiki/[code]/loading.tsx
+++ b/src/app/wiki/[code]/loading.tsx
@@ -1,9 +1,10 @@
 import LoadingOverlay from '@/components/common/LoadingOverlay';
 
 const Loading = () => {
+  console.log('로딩중');
   return (
     <div>
-      <LoadingOverlay>페이지를 불러오고 있어요</LoadingOverlay>
+      로딩중<LoadingOverlay>페이지를 불러오고 있어요</LoadingOverlay>
     </div>
   );
 };

--- a/src/components/common/MobileMenu.tsx
+++ b/src/components/common/MobileMenu.tsx
@@ -16,7 +16,6 @@ const MobileMenu = ({ hasNewNotifications, onNotificationClick }: MobileMenuProp
       label: '나의 위키',
       href: user?.profile?.code ? `/wiki/${user.profile.code}` : '/create-wiki',
     },
-    { label: '위키 생성하기', href: '/mypage' },
     { label: '설정', href: '/settings' },
     { label: '로그아웃', onClick: logout },
   ];

--- a/src/components/common/UserDropdown.tsx
+++ b/src/components/common/UserDropdown.tsx
@@ -17,7 +17,6 @@ const UserDropdown = ({ userImage }: Props) => {
       label: '나의 위키',
       href: user?.profile?.code ? `/wiki/${user.profile.code}` : '/create-wiki',
     },
-    { label: '위키 생성하기', href: '/mypage' },
     { label: '설정', href: '/settings' },
     { label: '로그아웃', onClick: logout },
   ];

--- a/src/components/common/WikiCreateForm.tsx
+++ b/src/components/common/WikiCreateForm.tsx
@@ -17,7 +17,7 @@ import Image from 'next/image';
 
 const WikiCreateForm = () => {
   const router = useRouter();
-  const { user, isAuthenticated, updateProfile } = useAuthContext(); // 로그인된 사용자 정보와 인증 상태 가져오기
+  const { user, isAuthenticated, updateProfile, isAuthLoading } = useAuthContext(); // 로그인된 사용자 정보와 인증 상태 가져오기
 
   const [selectedQuestion, setSelectedQuestion] = useState<string | null>(null);
   const [customInput, setCustomInput] = useState('');
@@ -33,6 +33,8 @@ const WikiCreateForm = () => {
 
   // 페이지 진입 시 기존 위키 존재 여부 확인
   useEffect(() => {
+    if (isAuthLoading) return;
+
     const checkExistingWiki = async () => {
       // 리다이렉트 중이라면 이 함수를 실행하지 않음
       if (isRedirecting) {

--- a/src/components/page/wikicode/WikiDetailSection.tsx
+++ b/src/components/page/wikicode/WikiDetailSection.tsx
@@ -15,6 +15,7 @@ import clsx from 'clsx';
 import ProfileIndex from './ProfileIndex/ProfileIndex';
 import { getHtmlHeadings } from '@/components/common/TextEditor/utils/handlers/getHtmlHeadings';
 import WikiInfo from './WikiInfo/WikiInfo';
+import { ToastRender } from 'cy-toast';
 import { useUnloadAlert } from '@/hooks/useUnloadAlert';
 import ProfileQnAEditor from './ProfileQnAEditor/ProfileQnAEditor';
 import { uploadFileAPI } from '@/api/uploadFileAPI';
@@ -122,6 +123,7 @@ const WikiDetailSection = ({ wikiData }: Props) => {
           'lg:max-w-[800px]',
         )}
       >
+        <ToastRender />
         <ProfileTitle
           handleCancelClick={handleCancelClick}
           handleUpdateProfileSubmit={handleUpdateProfileSubmit}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -7,7 +7,7 @@ import { UserData, UserProfile } from '@/types/user';
 
 // AuthContextTYpe이 제공할 값 정의
 interface AuthContextType {
-  isAuthenticated: boolean | undefined; // 로그인 여부
+  isAuthenticated: boolean; // 로그인 여부
   isAuthLoading: boolean;
   user: UserData | null; // 로그인한 사용자 정보
   accessToken: string | null; // API 요청에 사용할 접근 토큰
@@ -22,7 +22,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 // AuthProvider 컴포넌트 정의
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean | undefined>(undefined); // 현재 로그인 상태인지
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false); // 현재 로그인 상태인지
   const [user, setUser] = useState<UserData | null>(null); // 로그인한 사용자의 정보
   const [accessToken, setAccessToken] = useState<string | null>(null); // API 호출 시 필요한 토큰
   const [isAuthLoading, setIsAuthLoading] = useState(true);

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -7,7 +7,8 @@ import { UserData, UserProfile } from '@/types/user';
 
 // AuthContextTYpe이 제공할 값 정의
 interface AuthContextType {
-  isAuthenticated: boolean; // 로그인 여부
+  isAuthenticated: boolean | undefined; // 로그인 여부
+  isAuthLoading: boolean;
   user: UserData | null; // 로그인한 사용자 정보
   accessToken: string | null; // API 요청에 사용할 접근 토큰
   login: (accessToken: string, refreshToken: string, user: UserData, fromSignup?: boolean) => void; //로그인 처리 함수
@@ -21,9 +22,10 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 // AuthProvider 컴포넌트 정의
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false); // 현재 로그인 상태인지
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | undefined>(undefined); // 현재 로그인 상태인지
   const [user, setUser] = useState<UserData | null>(null); // 로그인한 사용자의 정보
   const [accessToken, setAccessToken] = useState<string | null>(null); // API 호출 시 필요한 토큰
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
 
   // 로그인 함수 정의: 외부에서 로그인 API 호출 성공 시 이 함수를 호출
   const login = useCallback(
@@ -88,13 +90,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const contextValue = useMemo(
     () => ({
       isAuthenticated,
+      isAuthLoading,
       accessToken,
       user,
       login,
       logout,
       updateProfile,
     }),
-    [isAuthenticated, accessToken, user, login, logout, updateProfile],
+    [isAuthenticated, isAuthLoading, accessToken, user, login, logout, updateProfile],
   );
 
   useEffect(() => {
@@ -121,6 +124,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     } else {
       setIsAuthenticated(false);
     }
+    setIsAuthLoading(false);
   }, []); // 빈 배열(`[]`)은 이 `useEffect` 훅이 컴포넌트가 처음 마운트될 때 딱 한 번만 실행되도록 한다.
 
   return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
[2025-08-02_01.webm](https://github.com/user-attachments/assets/c854b4f8-1f00-4ccd-9ec2-759f388e7ab9)

설정 페이지에 위키 생성하기로 이동하는 페이지로 이동하는 섹션을 추가했는데 

헤더의 드롭다운으로 사용할때와는 다르게 무조건 로그인페이지로 리다이렉트되는 이슈가 생겼습니다.

WikiCreateForm 컴포넌트의
<img width="412" height="116" alt="image" src="https://github.com/user-attachments/assets/1997c891-d4dc-46de-9431-b21e30da40ad" />
해당부분때문이였고

<img width="716" height="24" alt="image" src="https://github.com/user-attachments/assets/fe8fcbad-30a7-4144-a5ec-1b7514754f9a" />

isAuthenticated의 초기값이 false로 설정되어있어서
로그인되어있지 않다는 신호로 무조건 로그인 페이지로 리다이렉트 되는듯합니다

그래서 관련해결을 위해

권한 확인중인 정보를 표시하는 isAuthLoading 스테이트를 추가해서
권한 로딩이 끝나면 useEffect의 동작이 시작하도록 수정했고 
혹시 다른 이슈가 생길지 테스트 중인데 특별한 문제는 발견하지 못했습니다.

